### PR TITLE
Use GoalType over any in goal modals

### DIFF
--- a/src/components/CreateGoalModal.tsx
+++ b/src/components/CreateGoalModal.tsx
@@ -7,7 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useAuth } from '@/hooks/useAuth';
-import { dynamicDataService } from '@/services/dynamicDataService';
+import { dynamicDataService, type GoalType } from '@/services/dynamicDataService';
 import { useToast } from '@/hooks/use-toast';
 
 interface CreateGoalModalProps {
@@ -132,7 +132,7 @@ const CreateGoalModal = ({ onClose, onGoalCreated }: CreateGoalModalProps) => {
 
           <div className="space-y-2">
             <Label htmlFor="goal_type">Type d'objectif</Label>
-            <Select value={formData.goal_type} onValueChange={(value) => setFormData({ ...formData, goal_type: value as any })}>
+            <Select value={formData.goal_type} onValueChange={(value) => setFormData({ ...formData, goal_type: value as GoalType })}>
               <SelectTrigger>
                 <SelectValue placeholder="Sélectionnez un type" />
               </SelectTrigger>

--- a/src/components/EditGoalModal.tsx
+++ b/src/components/EditGoalModal.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { dynamicDataService, type UserGoal } from '@/services/dynamicDataService';
+import { dynamicDataService, type UserGoal, type GoalType } from '@/services/dynamicDataService';
 import { useToast } from '@/hooks/use-toast';
 
 interface EditGoalModalProps {
@@ -130,7 +130,7 @@ const EditGoalModal = ({ goal, onClose, onGoalUpdated }: EditGoalModalProps) => 
 
           <div className="space-y-2">
             <Label htmlFor="goal_type">Type d'objectif</Label>
-            <Select value={formData.goal_type} onValueChange={(value) => setFormData({ ...formData, goal_type: value as any })}>
+            <Select value={formData.goal_type} onValueChange={(value) => setFormData({ ...formData, goal_type: value as GoalType })}>
               <SelectTrigger>
                 <SelectValue placeholder="Sélectionnez un type" />
               </SelectTrigger>


### PR DESCRIPTION
## Summary
- import `GoalType` from `dynamicDataService`
- replace `value as any` with `value as GoalType`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b3bea3948325a918fbb64b1a689a