### PR TITLE
Update auth error typing

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,6 +1,6 @@
 
 import { useState, useEffect, createContext, useContext, ReactNode } from 'react';
-import { User, Session } from '@supabase/supabase-js';
+import { User, Session, AuthError } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
@@ -8,8 +8,8 @@ interface AuthContextType {
   user: User | null;
   session: Session | null;
   loading: boolean;
-  signUp: (email: string, password: string, name?: string) => Promise<{ error: any }>;
-  signIn: (email: string, password: string) => Promise<{ error: any }>;
+  signUp: (email: string, password: string, name?: string) => Promise<{ error: AuthError | null }>;
+  signIn: (email: string, password: string) => Promise<{ error: AuthError | null }>;
   signOut: () => Promise<void>;
 }
 
@@ -41,7 +41,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return () => subscription.unsubscribe();
   }, []);
 
-  const signUp = async (email: string, password: string, name?: string) => {
+  const signUp = async (
+    email: string,
+    password: string,
+    name?: string
+  ): Promise<{ error: AuthError | null }> => {
     try {
       const { error } = await supabase.auth.signUp({
         email,
@@ -69,13 +73,16 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       });
 
       return { error: null };
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Signup error:', error);
-      return { error };
+      return { error: error as AuthError };
     }
   };
 
-  const signIn = async (email: string, password: string) => {
+  const signIn = async (
+    email: string,
+    password: string
+  ): Promise<{ error: AuthError | null }> => {
     try {
       const { error } = await supabase.auth.signInWithPassword({
         email,
@@ -97,9 +104,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       });
 
       return { error: null };
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Signin error:', error);
-      return { error };
+      return { error: error as AuthError };
     }
   };
 


### PR DESCRIPTION
## Summary
- adjust auth hook return types to use `AuthError | null`
- update signIn/signUp to cast caught errors accordingly

## Testing
- `npm run lint` *(fails: unexpected any & other lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851b3bf8cc883258b5d78534f09b68c