### PR TITLE
Fix loader dependencies

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -19,7 +19,7 @@ const AdminPanel = () => {
   const [activeTab, setActiveTab] = useState<AdminTab>('users');
   const { toast } = useToast();
 
-  const loadUsers = async () => {
+  const loadUsers = useCallback(async () => {
     setLoading(true);
     try {
       const usersWithRoles = await roleService.getAllUsersWithRoles();
@@ -34,11 +34,11 @@ const AdminPanel = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast]);
 
   useEffect(() => {
     loadUsers();
-  }, []);
+  }, [loadUsers]);
 
   const handleRoleChange = async (userId: string, newRole: UserRole) => {
     try {

--- a/src/components/GoalsProgress.tsx
+++ b/src/components/GoalsProgress.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
@@ -19,15 +19,9 @@ const GoalsProgress = () => {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingGoal, setEditingGoal] = useState<UserGoal | null>(null);
 
-  useEffect(() => {
-    if (user) {
-      loadGoals();
-    }
-  }, [user]);
-
-  const loadGoals = async () => {
+  const loadGoals = useCallback(async () => {
     if (!user) return;
-    
+
     setLoading(true);
     try {
       const userGoals = await dynamicDataService.getUserGoals(user.id);
@@ -42,7 +36,11 @@ const GoalsProgress = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, toast]);
+
+  useEffect(() => {
+    loadGoals();
+  }, [loadGoals]);
 
   const calculateProgress = (goal: UserGoal): number => {
     if (goal.target_value === 0) return 0;

--- a/src/components/PlanManager.tsx
+++ b/src/components/PlanManager.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Plus, Settings, Trash2, Copy, Calendar, Target } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -42,11 +42,7 @@ const PlanManager = () => {
     }
   };
 
-  useEffect(() => {
-    loadPlans();
-  }, [user]);
-
-  const loadPlans = async () => {
+  const loadPlans = useCallback(async () => {
     if (!user) return;
 
     setLoading(true);
@@ -63,7 +59,11 @@ const PlanManager = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, toast]);
+
+  useEffect(() => {
+    loadPlans();
+  }, [loadPlans]);
 
   const activatePlan = async (planId: string) => {
     if (!user) return;


### PR DESCRIPTION
## Summary
- memoize `loadUsers` in `AdminPanel`
- memoize `loadGoals` in `GoalsProgress`
- memoize `loadPlans` in `PlanManager`

## Testing
- `npm run lint` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851b3bf89a48325821b21d30f05f251