### PR TITLE
Fix weight and calorie filtering

### DIFF
--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -101,7 +101,7 @@ export const useAppStore = create<AppState>()(
       getFilteredWeightData: () => {
         const { weightEntries, currentPeriod } = get();
         const now = new Date();
-        let cutoffDate = new Date();
+        const cutoffDate = new Date();
 
         switch (currentPeriod) {
           case '7d':
@@ -120,7 +120,7 @@ export const useAppStore = create<AppState>()(
       getFilteredCalorieData: () => {
         const { calorieEntries, currentPeriod } = get();
         const now = new Date();
-        let cutoffDate = new Date();
+        const cutoffDate = new Date();
 
         switch (currentPeriod) {
           case '7d':


### PR DESCRIPTION
## Summary
- use const instead of let for cutoffDate in data filtering helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851b3d1c0788325a79d067656951d78