### PR TITLE
Fix SettingsPage typings

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -8,13 +8,14 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useToast } from "@/hooks/use-toast";
 import { useSettings } from "@/hooks/useSettings";
+import { type AppSettings } from '@/schemas';
 
 const SettingsPage = () => {
   const { toast } = useToast();
   const { settings, updateSetting, resetSettings } = useSettings();
 
   const handleSettingChange = (key: string, value: boolean | string) => {
-    updateSetting(key as any, value);
+    updateSetting(key as keyof AppSettings, value);
     toast({
       title: "Paramètres mis à jour",
       description: "Vos préférences ont été enregistrées.",


### PR DESCRIPTION
## Summary
- fix SettingsPage by specifying `keyof AppSettings` in `updateSetting`
- import `AppSettings` interface

## Testing
- `npm ci` *(fails: could not resolve dependency)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6851b3c30e5c832599e2aed48a849bf0