### PR TITLE
Load profile data from Supabase

### DIFF
--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { profileService } from '@/services/supabaseServices';
+import type { Database } from '@/integrations/supabase/types';
+
+type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+
+export const useProfile = () => {
+  const { user } = useAuth();
+  const [profile, setProfile] = useState<ProfileRow | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      if (!user) return;
+      setLoading(true);
+      try {
+        const data = await profileService.getProfile(user.id);
+        setProfile(data);
+      } catch (error) {
+        console.error('Error loading profile:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadProfile();
+  }, [user]);
+
+  const updateProfile = async (updates: Partial<ProfileRow>) => {
+    if (!user) return;
+    await profileService.updateProfile(user.id, updates);
+    setProfile(prev => (prev ? { ...prev, ...updates } : prev));
+  };
+
+  return { profile, loading, updateProfile };
+};


### PR DESCRIPTION
## Summary
- add `useProfile` hook to retrieve profile information from Supabase
- update `ProfilePage` to pull data from the new hook and save updates

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68566a17e07c8325a1852f2a4295b4db