### PR TITLE
Add admin check for FoodLibrary tabs

### DIFF
--- a/src/components/FoodLibraryAdmin.tsx
+++ b/src/components/FoodLibraryAdmin.tsx
@@ -5,8 +5,11 @@ import FoodLibrarySupabase from './FoodLibrarySupabase';
 import FoodImporter from './FoodImporter';
 import FoodDataCleaner from './FoodDataCleaner';
 import { Database, Upload, Trash2 } from 'lucide-react';
+import { useRole } from '@/hooks/useRole';
 
 const FoodLibraryAdmin = () => {
+  const { isAdmin } = useRole();
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -14,32 +17,40 @@ const FoodLibraryAdmin = () => {
       </div>
 
       <Tabs defaultValue="library" className="space-y-6">
-        <TabsList className="grid w-full grid-cols-3">
+        <TabsList className={`grid w-full ${isAdmin ? 'grid-cols-3' : 'grid-cols-1'}`}>
           <TabsTrigger value="library" className="flex items-center space-x-2">
             <Database size={18} />
             <span>Bibliothèque</span>
           </TabsTrigger>
-          <TabsTrigger value="import" className="flex items-center space-x-2">
-            <Upload size={18} />
-            <span>Import CSV</span>
-          </TabsTrigger>
-          <TabsTrigger value="cleanup" className="flex items-center space-x-2">
-            <Trash2 size={18} />
-            <span>Nettoyage</span>
-          </TabsTrigger>
+          {isAdmin && (
+            <>
+              <TabsTrigger value="import" className="flex items-center space-x-2">
+                <Upload size={18} />
+                <span>Import CSV</span>
+              </TabsTrigger>
+              <TabsTrigger value="cleanup" className="flex items-center space-x-2">
+                <Trash2 size={18} />
+                <span>Nettoyage</span>
+              </TabsTrigger>
+            </>
+          )}
         </TabsList>
-        
+
         <TabsContent value="library">
           <FoodLibrarySupabase />
         </TabsContent>
-        
-        <TabsContent value="import">
-          <FoodImporter />
-        </TabsContent>
-        
-        <TabsContent value="cleanup">
-          <FoodDataCleaner />
-        </TabsContent>
+
+        {isAdmin && (
+          <>
+            <TabsContent value="import">
+              <FoodImporter />
+            </TabsContent>
+
+            <TabsContent value="cleanup">
+              <FoodDataCleaner />
+            </TabsContent>
+          </>
+        )}
       </Tabs>
     </div>
   );


### PR DESCRIPTION
## Summary
- show import and cleanup tabs only for admins in the food library

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856750aac94832597d6e6c3f7224c1d