### PR TITLE
Implement calorie goal adjustments

### DIFF
--- a/src/components/GoalsProgress.tsx
+++ b/src/components/GoalsProgress.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { CheckCircle, Circle, Target, Plus, Edit, Trash2 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { dynamicDataService, type UserGoal } from '@/services/dynamicDataService';
+import { useAppStore } from '@/stores/useAppStore';
 import { useToast } from '@/hooks/use-toast';
 import CreateGoalModal from './CreateGoalModal';
 import EditGoalModal from './EditGoalModal';
@@ -14,6 +15,7 @@ import EditGoalModal from './EditGoalModal';
 const GoalsProgress = () => {
   const { user } = useAuth();
   const { toast } = useToast();
+  const { recalculateCalorieTarget } = useAppStore();
   const [goals, setGoals] = useState<UserGoal[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -26,6 +28,12 @@ const GoalsProgress = () => {
     try {
       const userGoals = await dynamicDataService.getUserGoals(user.id);
       setGoals(userGoals);
+
+      const hasWeightGoal = userGoals.some(g => g.is_active && g.goal_type === 'weight_loss');
+      const hasMaintenanceGoal = userGoals.some(g => g.is_active && g.goal_type === 'nutrition');
+      if (hasWeightGoal || hasMaintenanceGoal) {
+        recalculateCalorieTarget();
+      }
     } catch (error) {
       console.error('Error loading goals:', error);
       toast({

--- a/src/utils/calorieUtils.ts
+++ b/src/utils/calorieUtils.ts
@@ -1,0 +1,29 @@
+export type ActivityLevel = 'sedentary' | 'light' | 'moderate' | 'active' | 'very_active';
+
+export interface CalorieCalcInput {
+  weight: number;
+  height: number;
+  age: number;
+  activityLevel: ActivityLevel;
+}
+
+const activityFactor: Record<ActivityLevel, number> = {
+  sedentary: 1.2,
+  light: 1.375,
+  moderate: 1.55,
+  active: 1.725,
+  very_active: 1.9,
+};
+
+export function calculateMaintenanceCalories({ weight, height, age, activityLevel }: CalorieCalcInput): number {
+  const bmr = 10 * weight + 6.25 * height - 5 * age;
+  return Math.round(bmr * activityFactor[activityLevel]);
+}
+
+export function calculateAdjustedCalories(input: CalorieCalcInput & { weightTarget: number }): number {
+  const maintenance = calculateMaintenanceCalories(input);
+  if (input.weightTarget < input.weight) {
+    return Math.max(1200, maintenance - 500);
+  }
+  return maintenance;
+}


### PR DESCRIPTION
## Summary
- compute maintenance calories and deficits
- recalc daily calories when user or goals change
- expose action to recompute calorie target
- trigger recalculation when goals are loaded

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685677c1420c832581c33a24700eca74