### PR TITLE
Refactor objectives UI

### DIFF
--- a/src/components/DashboardGoals.tsx
+++ b/src/components/DashboardGoals.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/useAuth';
+import { dynamicDataService, type UserGoal } from '@/services/dynamicDataService';
+import ObjectiveSummary from './ObjectiveSummary';
+
+interface DashboardGoalsProps {
+  onViewProgress: () => void;
+}
+
+const DashboardGoals = ({ onViewProgress }: DashboardGoalsProps) => {
+  const { user } = useAuth();
+  const [goals, setGoals] = useState<UserGoal[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) return;
+    setLoading(true);
+    dynamicDataService
+      .getUserGoals(user.id)
+      .then(setGoals)
+      .finally(() => setLoading(false));
+  }, [user]);
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Objectifs actifs</CardTitle>
+        <CardDescription>Suivi rapide de vos progrès</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p>Chargement...</p>
+        ) : goals.length === 0 ? (
+          <div className="space-y-2 text-center">
+            <p>Aucun objectif actif actuellement.</p>
+            <Button variant="link" onClick={onViewProgress} className="p-0 h-auto">
+              Fixez-en un dans la section Progression
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {goals.map((goal) => (
+              <ObjectiveSummary key={goal.id} goal={goal} />
+            ))}
+            <div className="text-right">
+              <Button variant="link" onClick={onViewProgress} className="p-0 h-auto">
+                Voir mes objectifs
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DashboardGoals;

--- a/src/components/GoalsProgress.tsx
+++ b/src/components/GoalsProgress.tsx
@@ -1,14 +1,13 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { CheckCircle, Circle, Target, Plus, Edit, Trash2 } from 'lucide-react';
+import { Target, Plus, Edit, Trash2 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { dynamicDataService, type UserGoal } from '@/services/dynamicDataService';
 import { useAppStore } from '@/stores/useAppStore';
 import { useToast } from '@/hooks/use-toast';
+import ObjectiveSummary from './ObjectiveSummary';
 import CreateGoalModal from './CreateGoalModal';
 import EditGoalModal from './EditGoalModal';
 
@@ -137,63 +136,27 @@ const GoalsProgress = () => {
             </div>
           ) : (
             <div className="space-y-6">
-              {goals.map((goal) => {
-                const progress = calculateProgress(goal);
-                const isCompleted = progress >= 100;
-                
-                return (
-                  <div key={goal.id} className="space-y-3 p-4 border rounded-lg">
-                    <div className="flex items-start justify-between">
-                      <div className="space-y-1 flex-1">
-                        <div className="flex items-center space-x-2">
-                          {isCompleted ? (
-                            <CheckCircle className="h-5 w-5 text-green-500" />
-                          ) : (
-                            <Circle className="h-5 w-5 text-muted-foreground" />
-                          )}
-                          <h4 className="font-medium">{goal.title}</h4>
-                          <Badge variant={isCompleted ? "default" : progress >= 80 ? "secondary" : "outline"}>
-                            {progress}%
-                          </Badge>
-                        </div>
-                        {goal.description && (
-                          <p className="text-sm text-muted-foreground">{goal.description}</p>
-                        )}
-                        <div className="flex items-center justify-between text-sm">
-                          <span>
-                            {goal.current_value} / {goal.target_value} {goal.unit}
-                          </span>
-                          {goal.deadline && (
-                            <span className="text-muted-foreground">
-                              Échéance: {new Date(goal.deadline).toLocaleDateString()}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                      <div className="flex items-center space-x-2 ml-4">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setEditingGoal(goal)}
-                        >
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleDeleteGoal(goal.id)}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-                    <Progress 
-                      value={progress} 
-                      className={`h-2 ${isCompleted ? 'bg-green-100' : ''}`}
-                    />
-                  </div>
-                );
-              })}
+              {goals.map((goal) => (
+                <ObjectiveSummary
+                  key={goal.id}
+                  goal={goal}
+                >
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setEditingGoal(goal)}
+                  >
+                    <Edit className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleDeleteGoal(goal.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </ObjectiveSummary>
+              ))}
             </div>
           )}
         </CardContent>

--- a/src/components/ObjectiveSummary.tsx
+++ b/src/components/ObjectiveSummary.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { CheckCircle, Circle } from 'lucide-react';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import type { UserGoal } from '@/services/dynamicDataService';
+
+interface ObjectiveSummaryProps {
+  goal: UserGoal;
+  children?: React.ReactNode;
+}
+
+const ObjectiveSummary = ({ goal, children }: ObjectiveSummaryProps) => {
+  const progress = goal.target_value === 0
+    ? 0
+    : Math.min(Math.round((goal.current_value / goal.target_value) * 100), 100);
+  const isCompleted = progress >= 100;
+
+  return (
+    <div className="space-y-3 p-4 border rounded-lg">
+      <div className="flex items-start justify-between">
+        <div className="space-y-1 flex-1">
+          <div className="flex items-center space-x-2">
+            {isCompleted ? (
+              <CheckCircle className="h-5 w-5 text-green-500" />
+            ) : (
+              <Circle className="h-5 w-5 text-muted-foreground" />
+            )}
+            <h4 className="font-medium">{goal.title}</h4>
+            <Badge variant={isCompleted ? 'default' : progress >= 80 ? 'secondary' : 'outline'}>
+              {progress}%
+            </Badge>
+          </div>
+          {goal.description && (
+            <p className="text-sm text-muted-foreground">{goal.description}</p>
+          )}
+          <div className="flex justify-between items-center text-sm">
+            <span>
+              {goal.current_value} / {goal.target_value} {goal.unit}
+            </span>
+            {goal.deadline && (
+              <span className="text-muted-foreground">
+                Échéance: {new Date(goal.deadline).toLocaleDateString()}
+              </span>
+            )}
+          </div>
+        </div>
+        {children && <div className="flex items-center space-x-2 ml-4">{children}</div>}
+      </div>
+      <Progress value={progress} className={`h-2 ${isCompleted ? 'bg-green-100' : ''}`} />
+    </div>
+  );
+};
+
+export default ObjectiveSummary;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,7 +11,7 @@ import SettingsPage from '@/components/SettingsPage';
 import AdminPanel from '@/components/AdminPanel';
 import AdminRoute from '@/components/AdminRoute';
 import NutritionStats from '@/components/NutritionStats';
-import GoalsProgress from '@/components/GoalsProgress';
+import DashboardGoals from '@/components/DashboardGoals';
 import CaloriesChart from '@/components/CaloriesChart';
 import WeightChart from '@/components/WeightChart';
 import NotificationCenter from '@/components/NotificationCenter';
@@ -67,7 +67,7 @@ const Index = () => {
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <NutritionStats />
-              <GoalsProgress />
+              <DashboardGoals onViewProgress={() => setActiveSection('progress')} />
             </div>
             
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -85,7 +85,7 @@ const Index = () => {
       case 'progress':
         return <ProgressPage />;
       case 'profile':
-        return <ProfilePage />;
+        return <ProfilePage onManageGoals={() => setActiveSection('progress')} />;
       case 'settings':
         return <SettingsPage />;
       case 'admin':


### PR DESCRIPTION
## Summary
- centralize full goal management in Progression page
- display objective summaries with new `ObjectiveSummary` component
- show active goals on the dashboard via `DashboardGoals`
- profile page now only shows read-only goal summaries
- navigation links to Progression page for goal management

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68568251ae488325a872e3f460b646ce