### PR TITLE
Fix progress page goal UI and score calc

### DIFF
--- a/src/components/CreateGoalModal.tsx
+++ b/src/components/CreateGoalModal.tsx
@@ -49,13 +49,21 @@ const CreateGoalModal = ({ onClose, onGoalCreated }: CreateGoalModalProps) => {
 
   const [selectedTemplate, setSelectedTemplate] =
     useState<keyof typeof goalTemplates | ''>('');
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<{
+    title: string;
+    description: string;
+    target_value: string;
+    current_value: string;
+    unit: string;
+    goal_type: GoalType;
+    deadline: string;
+  }>({
     title: '',
     description: '',
-    target_value: 0,
-    current_value: 0,
+    target_value: '',
+    current_value: '',
     unit: '',
-    goal_type: 'custom' as const,
+    goal_type: 'custom',
     deadline: ''
   });
 
@@ -79,6 +87,8 @@ const CreateGoalModal = ({ onClose, onGoalCreated }: CreateGoalModalProps) => {
     try {
       await dynamicDataService.createUserGoal(user.id, {
         ...formData,
+        target_value: parseFloat(formData.target_value) || 0,
+        current_value: parseFloat(formData.current_value) || 0,
         is_active: true
       });
       
@@ -160,7 +170,7 @@ const CreateGoalModal = ({ onClose, onGoalCreated }: CreateGoalModalProps) => {
                     id="target_value"
                     type="number"
                     value={formData.target_value}
-                    onChange={(e) => setFormData({ ...formData, target_value: parseFloat(e.target.value) || 0 })}
+                    onChange={(e) => setFormData({ ...formData, target_value: e.target.value })}
                     placeholder="10"
                     required
                     min="0"
@@ -200,7 +210,7 @@ const CreateGoalModal = ({ onClose, onGoalCreated }: CreateGoalModalProps) => {
                   id="current_value"
                   type="number"
                   value={formData.current_value}
-                  onChange={(e) => setFormData({ ...formData, current_value: parseFloat(e.target.value) || 0 })}
+                  onChange={(e) => setFormData({ ...formData, current_value: e.target.value })}
                   placeholder="0"
                   min="0"
                   step="0.1"

--- a/src/components/GoalsProgress.tsx
+++ b/src/components/GoalsProgress.tsx
@@ -113,10 +113,12 @@ const GoalsProgress = () => {
                 Suivez vos objectifs personnalisés et votre progression
               </CardDescription>
             </div>
-            <Button onClick={() => setShowCreateModal(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              Nouvel objectif
-            </Button>
+            {!loading && goals.length > 0 && (
+              <Button onClick={() => setShowCreateModal(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                Nouvel objectif
+              </Button>
+            )}
           </div>
         </CardHeader>
         <CardContent>

--- a/src/hooks/useProgressStats.ts
+++ b/src/hooks/useProgressStats.ts
@@ -147,7 +147,9 @@ export const useProgressStats = () => {
     const planComplianceRate = (filteredCalories.length / totalDays) * 100;
 
     // Score global amélioré
-    const weightProgress = Math.max(0, Math.min(100, 100 - Math.abs(weightChange) * 10));
+    const weightProgress = filteredWeights.length >= 2
+      ? Math.max(0, Math.min(100, 100 - Math.abs(weightChange) * 10))
+      : 0;
     const calorieProgress = filteredCalories.length > 0 
       ? (goalsAchieved / filteredCalories.length) * 100 
       : 0;


### PR DESCRIPTION
## Summary
- hide "Nouvel objectif" button when no goals exist
- empty goal value fields by default
- parse number values on submit only
- avoid default 20% global score when no weight data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568d95ed3083259ec965ebafa852e0