### PR TITLE
Add weight entry tracking

### DIFF
--- a/src/components/CreateGoalModal.tsx
+++ b/src/components/CreateGoalModal.tsx
@@ -251,7 +251,7 @@ const CreateGoalModal = ({ onClose, onGoalCreated }: CreateGoalModalProps) => {
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="tracking_interval">Intervalle</Label>
+              <Label htmlFor="tracking_interval">Intervalle de mesure</Label>
               <Select value={formData.tracking_interval} onValueChange={(v) => setFormData({ ...formData, tracking_interval: v as 'jour' | 'semaine' | 'mois' })}>
                 <SelectTrigger>
                   <SelectValue placeholder="Intervalle" />
@@ -264,7 +264,7 @@ const CreateGoalModal = ({ onClose, onGoalCreated }: CreateGoalModalProps) => {
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="tracking_repetition">Répétitions</Label>
+              <Label htmlFor="tracking_repetition">Fréquence</Label>
               <Input
                 id="tracking_repetition"
                 type="number"

--- a/src/components/EditGoalModal.tsx
+++ b/src/components/EditGoalModal.tsx
@@ -196,7 +196,7 @@ const EditGoalModal = ({ goal, onClose, onGoalUpdated }: EditGoalModalProps) => 
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="tracking_interval">Intervalle</Label>
+              <Label htmlFor="tracking_interval">Intervalle de mesure</Label>
               <Select value={formData.tracking_interval} onValueChange={(v) => setFormData({ ...formData, tracking_interval: v as 'jour' | 'semaine' | 'mois' })}>
                 <SelectTrigger>
                   <SelectValue placeholder="Intervalle" />
@@ -209,7 +209,7 @@ const EditGoalModal = ({ goal, onClose, onGoalUpdated }: EditGoalModalProps) => 
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="tracking_repetition">Répétitions</Label>
+              <Label htmlFor="tracking_repetition">Fréquence</Label>
               <Input
                 id="tracking_repetition"
                 type="number"

--- a/src/components/ProgressPage.tsx
+++ b/src/components/ProgressPage.tsx
@@ -6,6 +6,7 @@ import WeightChart from './WeightChart';
 import CaloriesChart from './CaloriesChart';
 import ProgressStats from './ProgressStats';
 import GoalsProgress from './GoalsProgress';
+import WeightEntrySection from './WeightEntrySection';
 import { TrendingUp, TrendingDown, Target, Calendar } from 'lucide-react';
 import PeriodSelector from "./PeriodSelector";
 import { useAppStore } from '../stores/useAppStore';
@@ -139,6 +140,7 @@ const ProgressPage = () => {
               </div>
             </CardContent>
           </Card>
+          <WeightEntrySection />
         </TabsContent>
 
         <TabsContent value="nutrition" className="space-y-6">

--- a/src/components/WeightEntrySection.tsx
+++ b/src/components/WeightEntrySection.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/hooks/useAuth';
+import { weightService } from '@/services/supabaseServices';
+import { useToast } from '@/hooks/use-toast';
+import type { WeightEntry } from '@/schemas';
+
+const WeightEntrySection = () => {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [weight, setWeight] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [entries, setEntries] = useState<WeightEntry[]>([]);
+
+  const loadEntries = async () => {
+    if (!user) return;
+    const data = await weightService.getWeightEntries(user.id);
+    setEntries(data);
+  };
+
+  useEffect(() => {
+    loadEntries();
+  }, [user]);
+
+  const handleAdd = async () => {
+    if (!user || !weight) return;
+    setLoading(true);
+    try {
+      await weightService.addWeightEntry(user.id, parseFloat(weight));
+      await loadEntries();
+      setWeight('');
+      toast({ title: 'Poids enregistré' });
+    } catch (error) {
+      toast({
+        title: 'Erreur',
+        description: "Impossible d'enregistrer le poids.",
+        variant: 'destructive'
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Saisie du poids</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex space-x-2">
+          <Input
+            type="number"
+            placeholder="kg"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            className="flex-1"
+          />
+          <Button onClick={handleAdd} disabled={loading || !weight}>
+            Ajouter
+          </Button>
+        </div>
+        {entries.length > 0 && (
+          <ul className="text-sm space-y-1">
+            {entries.slice(-5).reverse().map((e) => (
+              <li key={e.id} className="flex justify-between">
+                <span>{new Date(e.date).toLocaleDateString('fr-FR')}</span>
+                <span>{e.weight} kg</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default WeightEntrySection;


### PR DESCRIPTION
## Summary
- tweak goal creation labels for better measurement scheduling
- add weight entry tracking section
- display weight input after progress charts

## Testing
- `npm run lint`
- `npm test -- -t "NotFound page"`

------
https://chatgpt.com/codex/tasks/task_e_6856a44173a88325b9e55044d6d1aa94