### PR TITLE
Improve InlineEditableInput accessibility

### DIFF
--- a/src/components/InlineEditableInput.tsx
+++ b/src/components/InlineEditableInput.tsx
@@ -31,7 +31,18 @@ const InlineEditableInput: React.FC<InlineEditableInputProps> = ({
       {saved && <Check className="absolute right-2 top-1/2 -translate-y-1/2 text-green-500" size={16} />}
     </div>
   ) : (
-    <span onDoubleClick={startEditing} className="cursor-pointer">
+    <span
+      role="button"
+      tabIndex={0}
+      onDoubleClick={startEditing}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          startEditing();
+        }
+      }}
+      className="cursor-pointer"
+    >
       {initial || '—'}
     </span>
   );


### PR DESCRIPTION
## Summary
- add keyboard handlers to allow editing via Enter or Space
- mark display span as a button so it can receive focus

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857f394be688325a200f70713a960cb