### PR TITLE
Fix validation regex on optional fields

### DIFF
--- a/src/hooks/useProfileValidation.ts
+++ b/src/hooks/useProfileValidation.ts
@@ -4,9 +4,9 @@ import { z } from 'zod';
 const schema = z.object({
   email: z.string().email({ message: 'Email invalide' }),
 
-  age: z.string().optional().regex(/^\d*$/, 'Nombre uniquement'),
-  weight: z.string().optional().regex(/^\d*(\.\d+)?$/, 'Nombre'),
-  height: z.string().optional().regex(/^\d*(\.\d+)?$/, 'Nombre'),
+  age: z.string().regex(/^\d*$/, 'Nombre uniquement').optional(),
+  weight: z.string().regex(/^\d*(\.\d+)?$/, 'Nombre').optional(),
+  height: z.string().regex(/^\d*(\.\d+)?$/, 'Nombre').optional(),
 
   phone: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- fix useProfileValidation regex validation chain order so `.regex()` is applied before `.optional()`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6858470706cc8325a252fad5c8506d1f