### PR TITLE
Add default color-scheme for light theme

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -45,6 +45,7 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    color-scheme: light;
   }
 
   * {


### PR DESCRIPTION
## Summary
- ensure the root theme specifies `color-scheme: light`
- keep the dark theme override intact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af1e9c41883259960c2f4bdddb136