### PR TITLE
Fix NutritionStats JSX parse error

### DIFF
--- a/src/components/NutritionStats.tsx
+++ b/src/components/NutritionStats.tsx
@@ -179,9 +179,7 @@ const NutritionStats = () => {
             </div>
           </div>
           <Button
- ewct44-codex/mettre-à-jour-le-style-du-bouton--ajouter
             className="px-4 py-2 rounded-md font-bold text-white bg-gradient-to-r from-indigo-500 to-blue-500 shadow hover:brightness-110 transition cursor-pointer border border-blue-400/20"
-
             onClick={handleAddWater}
           >
             <Plus className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- remove stray text in NutritionStats button causing parse error

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_685afcf13e4c8325aa963837cf268080