### PR TITLE
Add macronutrient icons component

### DIFF
--- a/src/components/MacroIcons.tsx
+++ b/src/components/MacroIcons.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Fish, Pill, Droplet } from 'lucide-react'
+
+interface MacroData {
+  current: number
+  target: number
+}
+
+interface MacroIconsProps {
+  proteins: MacroData
+  carbs: MacroData
+  fats: MacroData
+}
+
+const MacroIcons = ({ proteins, carbs, fats }: MacroIconsProps) => {
+  const macros = [
+    { label: 'Protéines', data: proteins, Icon: Fish },
+    { label: 'Glucides', data: carbs, Icon: Pill },
+    { label: 'Lipides', data: fats, Icon: Droplet }
+  ]
+
+  return (
+    <div className="flex justify-around">
+      {macros.map(({ label, data, Icon }) => {
+        const percentage = data.target > 0 ? Math.round((data.current / data.target) * 100) : 0
+        return (
+          <div key={label} className="flex flex-col items-center space-y-1">
+            <div className="w-12 h-12 rounded-full border border-gray-500/40 flex items-center justify-center">
+              <Icon size={20} className="text-gray-400" />
+            </div>
+            <span className="text-sm font-semibold text-white">{label}</span>
+            <span className="text-xs text-gray-400">{percentage}%</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default MacroIcons

--- a/src/components/NutritionStats.tsx
+++ b/src/components/NutritionStats.tsx
@@ -1,61 +1,10 @@
 import React, { useState } from 'react';
-import { Utensils, Flame, Droplets, TrendingDown, Minus, TrendingUp, Plus } from 'lucide-react';
+import { Utensils, Droplets, TrendingDown, Minus, TrendingUp, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useToast } from "@/hooks/use-toast";
 import { useNutritionStats } from '../hooks/useNutritionStats';
+import MacroIcons from './MacroIcons';
 
-interface MacroCircleProps {
-  label: string;
-  current: number;
-  target: number;
-  color: string;
-  unit: string;
-}
-
-const MacroCircle = ({ label, current, target, color, unit }: MacroCircleProps) => {
-  const percentage = Math.min((current / target) * 100, 100);
-  const circumference = 2 * Math.PI * 40;
-  const strokeDasharray = circumference;
-  const strokeDashoffset = circumference - (percentage / 100) * circumference;
-
-  return (
-    <div className="flex flex-col items-center">
-      <div className="relative w-20 h-20">
-        <svg className="w-20 h-20 transform -rotate-90" viewBox="0 0 88 88">
-          <circle
-            cx="44"
-            cy="44"
-            r="40"
-            stroke="currentColor"
-            strokeWidth="5"
-            fill="transparent"
-            className="text-gray-200 dark:text-gray-700"
-          />
-          <circle
-            cx="44"
-            cy="44"
-            r="40"
-            stroke={color}
-            strokeWidth="5"
-            fill="transparent"
-            strokeDasharray={strokeDasharray}
-            strokeDashoffset={strokeDashoffset}
-            className="transition-all duration-1000 ease-out"
-            strokeLinecap="round"
-          />
-        </svg>
-        <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <span className="text-xs font-bold text-gray-900 dark:text-gray-100">{current}</span>
-          <span className="text-xs text-gray-500 dark:text-gray-400">/{target}</span>
-        </div>
-      </div>
-      <div className="mt-2 text-center">
-        <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{label}</p>
-        <p className="text-xs text-gray-500 dark:text-gray-400">{unit}</p>
-      </div>
-    </div>
-  );
-};
 
 const NutritionStats = () => {
   const { toast } = useToast();
@@ -142,29 +91,11 @@ const NutritionStats = () => {
       </div>
 
       {/* Macronutriments */}
-      <div className="grid grid-cols-3 gap-3 md:gap-4">
-        <MacroCircle
-          label="Protéines"
-          current={stats.proteins.current}
-          target={stats.proteins.target}
-          color="#10B981"
-          unit="g"
-        />
-        <MacroCircle
-          label="Glucides"
-          current={stats.carbs.current}
-          target={stats.carbs.target}
-          color="#3B82F6"
-          unit="g"
-        />
-        <MacroCircle
-          label="Lipides"
-          current={stats.fats.current}
-          target={stats.fats.target}
-          color="#F59E0B"
-          unit="g"
-        />
-      </div>
+      <MacroIcons
+        proteins={stats.proteins}
+        carbs={stats.carbs}
+        fats={stats.fats}
+      />
 
       {/* Hydratation */}
       <div className="bg-gradient-to-r from-blue-50 to-cyan-50 dark:from-blue-900/20 dark:to-cyan-900/20 rounded-xl p-4">


### PR DESCRIPTION
## Summary
- display macronutrient values with icons instead of progress circles
- create `MacroIcons` component
- use `MacroIcons` in dashboard nutrition card

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68602f21c1b483259127300cd1e18125