### PR TITLE
Refine meal icon design

### DIFF
--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -57,7 +57,7 @@ const MealCard: React.FC<MealCardProps> = ({
     <div className="bg-white dark:bg-gray-800 rounded-3xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 transition-all duration-300 hover:shadow-xl hover:scale-102 group">
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center space-x-4">
-          <div className="w-14 h-14 bg-gradient-to-r from-green-400 via-blue-500 to-purple-500 rounded-2xl flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform duration-300">
+          <div className="w-10 h-10 bg-gradient-to-br from-[#3b0764] via-[#312e81] to-[#0f172a] rounded-xl flex items-center justify-center text-white shadow-lg group-hover:scale-110 transition-transform duration-300">
             {mealIcon}
           </div>
           <div>

--- a/src/components/mealIcons.tsx
+++ b/src/components/mealIcons.tsx
@@ -22,18 +22,18 @@ const getMealIconFallback = (mealName: string, size: number = 18, className?: st
   switch (mealName) {
     case 'breakfast':
     case 'Petit-déjeuner':
-      return React.createElement(Coffee, { size, className: className || "text-blue-500" });
+      return React.createElement(Coffee, { size, className: className || "text-white" });
     case 'lunch':
     case 'Déjeuner':
-      return React.createElement(Utensils, { size, className: className || "text-green-600" });
+      return React.createElement(Utensils, { size, className: className || "text-white" });
     case 'snack':
     case 'Collation':
-      return React.createElement(CakeSlice, { size, className: className || "text-pink-500" });
+      return React.createElement(CakeSlice, { size, className: className || "text-white" });
     case 'dinner':
     case 'Dîner':
-      return React.createElement(Egg, { size, className: className || "text-yellow-600" });
+      return React.createElement(Egg, { size, className: className || "text-white" });
     default:
-      return React.createElement(Clock, { size, className });
+      return React.createElement(Clock, { size, className: className || "text-white" });
   }
 };
 
@@ -60,7 +60,7 @@ export const getMealIcon = async (mealTypeKey: string, size: number = 18, classN
 
   // Obtenir l'icône correspondante
   const IconComponent = iconMapping[mealType.icon_name] || Clock;
-  return React.createElement(IconComponent, { size, className });
+  return React.createElement(IconComponent, { size, className: className || "text-white" });
 };
 
 // Hook pour utiliser les icônes de repas dans les composants React


### PR DESCRIPTION
## Summary
- tweak meal icon container styles for a premium look
- set meal icon colors to white by default

## Testing
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6860f811d1988325889a1f9e0fd23044