### PR TITLE
Add CalorieProgress component

### DIFF
--- a/src/__tests__/CalorieProgress.test.tsx
+++ b/src/__tests__/CalorieProgress.test.tsx
@@ -1,0 +1,13 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import CalorieProgress from "../components/CalorieProgress";
+import { describe, it, expect } from "vitest";
+
+describe("CalorieProgress", () => {
+  it("renders progress text and bar", () => {
+    render(<CalorieProgress currentCalories={200} targetCalories={400} />);
+    expect(screen.getByText("200 / 400 kcal (50%)")).toBeInTheDocument();
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveStyle("width: 50%");
+  });
+});

--- a/src/components/CalorieProgress.tsx
+++ b/src/components/CalorieProgress.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface CalorieProgressProps {
+  currentCalories: number;
+  targetCalories: number;
+}
+
+const CalorieProgress: React.FC<CalorieProgressProps> = ({ currentCalories, targetCalories }) => {
+  const percentage = targetCalories > 0 ? Math.min(Math.round((currentCalories / targetCalories) * 100), 100) : 0;
+
+  return (
+    <div className="space-y-2">
+      <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+        {currentCalories} / {targetCalories} kcal ({percentage}%)
+      </div>
+      <div className="w-full bg-gray-700 rounded-full h-2 overflow-hidden">
+        <div
+          className="bg-indigo-500 h-2 rounded-full transition-all duration-300"
+          style={{ width: `${percentage}%` }}
+          role="progressbar"
+          aria-valuenow={percentage}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CalorieProgress;


### PR DESCRIPTION
## Summary
- add `CalorieProgress` component to show meal calorie progress
- test component rendering logic

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6860ffba85d08325b5e852fdfaff890a