### PR TITLE
Update Supabase integration and types

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Users, Shield, UserCog, Database } from 'lucide-react';
 import { roleService, UserWithRole } from '@/services/roleService';
 import { useToast } from '@/hooks/use-toast';
-import { Database as DatabaseType } from '@/integrations/supabase/types';
+import { Database as DatabaseType } from '@/types/supabase';
 import FoodLibraryAdmin from './FoodLibraryAdmin';
 
 type UserRole = DatabaseType['public']['Enums']['app_role'];

--- a/src/components/EditPlanModal.tsx
+++ b/src/components/EditPlanModal.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import type { Database } from '@/integrations/supabase/types';
+import type { Database } from '@/types/supabase';
 
 type NutritionalPlan = Database['public']['Tables']['nutrition_plans']['Row'];
 

--- a/src/components/FoodCard.tsx
+++ b/src/components/FoodCard.tsx
@@ -1,0 +1,52 @@
+import type { FoodClean } from '@/types/supabase'
+
+interface Props {
+  food: FoodClean
+}
+
+const FoodCard = ({ food }: Props) => (
+  <div className="rounded-lg border bg-white p-4 space-y-2">
+    <h3 className="font-semibold">{food.name_fr}</h3>
+    <p className="text-sm text-gray-500">{food.group_fr}</p>
+    <div className="grid grid-cols-2 gap-2 text-sm">
+      <div className="text-center">
+        <p className="font-bold text-orange-600">{food.kcal}</p>
+        <p className="text-xs">kcal</p>
+      </div>
+      <div className="text-center">
+        <p className="font-bold text-green-600">{food.protein_g}g</p>
+        <p className="text-xs">protéines</p>
+      </div>
+    </div>
+    <div className="grid grid-cols-3 gap-1 text-xs text-gray-600">
+      <div className="text-center">
+        <p className="font-medium">{food.carb_g}g</p>
+        <p>Glucides</p>
+      </div>
+      <div className="text-center">
+        <p className="font-medium">{food.fat_g}g</p>
+        <p>Lipides</p>
+      </div>
+      <div className="text-center">
+        <p className="font-medium">{food.fiber_g}g</p>
+        <p>Fibres</p>
+      </div>
+    </div>
+    <div className="grid grid-cols-3 gap-1 text-xs text-gray-600">
+      <div className="text-center">
+        <p className="font-medium">{food.sugars_g}g</p>
+        <p>Sucres</p>
+      </div>
+      <div className="text-center">
+        <p className="font-medium">{food.sat_fat_g}g</p>
+        <p>AGS</p>
+      </div>
+      <div className="text-center">
+        <p className="font-medium">{food.salt_g}g</p>
+        <p>Sel</p>
+      </div>
+    </div>
+  </div>
+)
+
+export default FoodCard

--- a/src/components/FoodLibrarySupabase.tsx
+++ b/src/components/FoodLibrarySupabase.tsx
@@ -44,7 +44,7 @@ const FoodLibrarySupabase = () => {
     });
   };
 
-  const handleAddToMeal = async (foodId: string) => {
+  const handleAddToMeal = async (foodId: number) => {
     if (!user) {
       toast({
         title: "Connexion requise",
@@ -69,7 +69,7 @@ const FoodLibrarySupabase = () => {
     }
   };
 
-  const handleToggleFavorite = async (foodId: string) => {
+  const handleToggleFavorite = async (foodId: number) => {
     if (!user) {
       toast({
         title: "Connexion requise",

--- a/src/components/PlanManager.tsx
+++ b/src/components/PlanManager.tsx
@@ -9,7 +9,7 @@ import { nutritionPlanService } from '@/services/nutritionPlanService';
 import { useToast } from "@/hooks/use-toast";
 import CreatePlanModal from './CreatePlanModal';
 import EditPlanModal from './EditPlanModal';
-import type { Database } from '@/integrations/supabase/types';
+import type { Database } from '@/types/supabase';
 
 type NutritionalPlan = Database['public']['Tables']['nutrition_plans']['Row'];
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,7 +1,7 @@
 
 import { useState, useEffect, createContext, useContext, ReactNode } from 'react';
 import { User, Session, AuthError } from '@supabase/supabase-js';
-import { supabase } from '@/integrations/supabase/client';
+import supabase from '@/lib/supabase';
 import { useToast } from '@/hooks/use-toast';
 
 interface AuthContextType {

--- a/src/hooks/useFoods.ts
+++ b/src/hooks/useFoods.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import supabase from '@/lib/supabase'
+import type { FoodClean } from '@/types/supabase'
+
+const PAGE_SIZE = 20
+
+interface Params {
+  search?: string
+  page?: number
+  limit?: number
+}
+
+export function useFoods({ search = '', page = 0, limit = PAGE_SIZE }: Params) {
+  const [foods, setFoods] = useState<FoodClean[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    ;(async () => {
+      setLoading(true)
+      const from = page * limit
+      const to = from + limit - 1
+      let query = supabase
+        .from('foods_clean')
+        .select('*', { count: 'exact' })
+        .range(from, to)
+      if (search) {
+        query = query.ilike('name_fr', `%${search}%`)
+      }
+      const { data, error } = await query
+      if (!mounted) return
+      if (error) {
+        setError(error.message)
+      } else {
+        setFoods(data as FoodClean[])
+      }
+      setLoading(false)
+    })()
+    return () => {
+      mounted = false
+    }
+  }, [search, page, limit])
+
+  return { foods, loading, error }
+}

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { profileService } from '@/services/supabaseServices';
-import type { Database } from '@/integrations/supabase/types';
+import type { Database } from '@/types/supabase';
 
 type ProfileRow = Database['public']['Tables']['profiles']['Row'];
 

--- a/src/hooks/useRole.tsx
+++ b/src/hooks/useRole.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { roleService } from '@/services/roleService';
-import { Database } from '@/integrations/supabase/types';
+import { Database } from '@/types/supabase';
 
 type UserRole = Database['public']['Enums']['app_role'];
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/supabase'
+
+const supabase = createClient<Database>(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!
+)
+
+export default supabase

--- a/src/services/csvProcessor.ts
+++ b/src/services/csvProcessor.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import supabase from '@/lib/supabase';
 import { ImportStats, ImportError } from '@/types/import';
 import { detectSeparator, parseCSVLine, createColumnMappingSync } from '@/utils/csvUtils';
 import { validateFoodItem, createFoodItem } from '@/utils/foodValidation';

--- a/src/services/dynamicDataService.ts
+++ b/src/services/dynamicDataService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import supabase from '@/lib/supabase';
 
 export interface CategoryMapping {
   id: string;

--- a/src/services/food/favoritesService.ts
+++ b/src/services/food/favoritesService.ts
@@ -1,9 +1,9 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import supabase from '@/lib/supabase';
 import { Food, ExtendedFood } from '@/types/food';
 
 export class FavoritesService {
-  async getUserFavorites(userId: string): Promise<string[]> {
+  async getUserFavorites(userId: string): Promise<number[]> {
     try {
       const { data: favorites, error } = await supabase
         .from('user_food_favorites')
@@ -36,7 +36,7 @@ export class FavoritesService {
     }));
   }
 
-  async toggleFavorite(foodId: string, userId: string): Promise<boolean> {
+  async toggleFavorite(foodId: number, userId: string): Promise<boolean> {
     try {
       // Check if favorite already exists
       const { data: existing, error: checkError } = await supabase

--- a/src/services/food/foodRepository.ts
+++ b/src/services/food/foodRepository.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import supabase from '@/lib/supabase';
 import { Food, FoodInsert } from '@/types/food';
 
 export class FoodRepository {

--- a/src/services/food/mealService.ts
+++ b/src/services/food/mealService.ts
@@ -1,11 +1,11 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import supabase from '@/lib/supabase';
 
 export class MealService {
   async addMealEntry(
     userId: string,
-    foodId: string,
-    quantity: number,
+    foodId: number,
+    grams: number,
     mealType: 'breakfast' | 'lunch' | 'dinner' | 'snack'
   ): Promise<boolean> {
     try {
@@ -14,9 +14,9 @@ export class MealService {
         .insert({
           user_id: userId,
           food_id: foodId,
-          quantity,
+          grams,
           meal_type: mealType,
-          date: new Date().toISOString()
+          eaten_at: new Date().toISOString()
         });
 
       if (error) {

--- a/src/services/nutritionPlanService.ts
+++ b/src/services/nutritionPlanService.ts
@@ -1,6 +1,6 @@
 
-import { supabase } from '@/integrations/supabase/client';
-import type { Database } from '@/integrations/supabase/types';
+import supabase from '@/lib/supabase';
+import type { Database } from '@/types/supabase';
 
 type NutritionPlan = Database['public']['Tables']['nutrition_plans']['Row'];
 type PlannedMeal = Database['public']['Tables']['planned_meals']['Row'];
@@ -141,7 +141,7 @@ export const plannedMealService = {
     }
   },
 
-  async addFoodToMeal(plannedMealId: string, foodId: string, quantity: number) {
+  async addFoodToMeal(plannedMealId: string, foodId: number, quantity: number) {
     const { error } = await supabase
       .from('planned_meal_foods')
       .insert({

--- a/src/services/roleService.ts
+++ b/src/services/roleService.ts
@@ -1,6 +1,6 @@
 
-import { supabase } from '@/integrations/supabase/client';
-import { Database } from '@/integrations/supabase/types';
+import supabase from '@/lib/supabase';
+import { Database } from '@/types/supabase';
 
 type UserRole = Database['public']['Enums']['app_role'];
 

--- a/src/services/supabaseFoodService.ts
+++ b/src/services/supabaseFoodService.ts
@@ -46,7 +46,7 @@ class SupabaseFoodService {
     return foodDataService.searchFoods(foods, searchTerm, subgroup, showFavoritesOnly);
   }
 
-  async toggleFavorite(foodId: string, userId: string): Promise<boolean> {
+  async toggleFavorite(foodId: number, userId: string): Promise<boolean> {
     return await favoritesService.toggleFavorite(foodId, userId);
   }
 
@@ -61,11 +61,11 @@ class SupabaseFoodService {
 
   async addMealEntry(
     userId: string,
-    foodId: string,
-    quantity: number,
+    foodId: number,
+    grams: number,
     mealType: 'breakfast' | 'lunch' | 'dinner' | 'snack'
   ): Promise<boolean> {
-    return await mealService.addMealEntry(userId, foodId, quantity, mealType);
+    return await mealService.addMealEntry(userId, foodId, grams, mealType);
   }
 }
 

--- a/src/services/supabaseServices.ts
+++ b/src/services/supabaseServices.ts
@@ -1,5 +1,5 @@
-import { supabase } from '@/integrations/supabase/client';
-import type { Database } from '@/integrations/supabase/types';
+import supabase from '@/lib/supabase';
+import type { Database } from '@/types/supabase';
 
 // Type definitions from the database
 type Profile = Database['public']['Tables']['profiles']['Row'];
@@ -124,7 +124,7 @@ export const foodService = {
     return data || [];
   },
 
-  async getUserFavorites(userId: string): Promise<string[]> {
+  async getUserFavorites(userId: string): Promise<number[]> {
     const { data, error } = await supabase
       .from('user_food_favorites')
       .select('food_id')
@@ -137,7 +137,7 @@ export const foodService = {
     return data?.map(f => f.food_id) || [];
   },
 
-  async toggleFavorite(userId: string, foodId: string) {
+  async toggleFavorite(userId: string, foodId: number) {
     // Check if already favorite
     const { data: existing } = await supabase
       .from('user_food_favorites')
@@ -181,13 +181,13 @@ export const mealService = {
       startOfDay.setHours(0, 0, 0, 0);
       const endOfDay = new Date(date);
       endOfDay.setHours(23, 59, 59, 999);
-      
+
       query = query
-        .gte('date', startOfDay.toISOString())
-        .lte('date', endOfDay.toISOString());
+        .gte('eaten_at', startOfDay.toISOString())
+        .lte('eaten_at', endOfDay.toISOString());
     }
 
-    const { data, error } = await query.order('date', { ascending: false });
+    const { data, error } = await query.order('eaten_at', { ascending: false });
     
     if (error) {
       console.error('Error fetching meal entries:', error);
@@ -196,15 +196,15 @@ export const mealService = {
     return data || [];
   },
 
-  async addMealEntry(userId: string, foodId: string, quantity: number, mealType: string, date?: Date) {
+  async addMealEntry(userId: string, foodId: number, grams: number, eatenAt?: Date) {
     const { error } = await supabase
       .from('meal_entries')
       .insert({
         user_id: userId,
         food_id: foodId,
-        quantity,
+        grams,
         meal_type: mealType,
-        date: date?.toISOString() || new Date().toISOString()
+        eaten_at: eatenAt?.toISOString() || new Date().toISOString()
       });
     
     if (error) {

--- a/src/stores/useSupabaseFoodStore.ts
+++ b/src/stores/useSupabaseFoodStore.ts
@@ -17,8 +17,8 @@ interface SupabaseFoodState {
   setSearchTerm: (term: string) => void;
   setSelectedSubgroup: (subgroup: string) => void;
   setShowFavoritesOnly: (show: boolean) => void;
-  toggleFavorite: (foodId: string) => Promise<void>;
-  addMealEntry: (foodId: string, quantity: number, mealType: 'breakfast' | 'lunch' | 'dinner' | 'snack') => Promise<boolean>;
+  toggleFavorite: (foodId: number) => Promise<void>;
+  addMealEntry: (foodId: number, quantity: number, mealType: 'breakfast' | 'lunch' | 'dinner' | 'snack') => Promise<boolean>;
   getFilteredFoods: () => ExtendedFood[];
   refreshData: () => Promise<void>;
 }

--- a/src/types/food.ts
+++ b/src/types/food.ts
@@ -1,5 +1,5 @@
 
-import { Database } from '@/integrations/supabase/types';
+import { Database } from '@/types/supabase';
 
 export type Food = Database['public']['Tables']['foods']['Row'];
 export type FoodInsert = Database['public']['Tables']['foods']['Insert'];

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,40 @@
+import type { Database as GeneratedDatabase } from '@/integrations/supabase/types'
+
+export type Database = GeneratedDatabase
+
+export interface FoodClean {
+  id: number
+  name_fr: string
+  group_fr: string
+  kcal: number
+  protein_g: number
+  carb_g: number
+  fat_g: number
+  sugars_g: number
+  fiber_g: number
+  sat_fat_g: number
+  salt_g: number
+}
+
+export interface MealEntry {
+  id: string
+  user_id: string
+  food_id: number
+  grams: number
+  eaten_at: string
+}
+
+export interface Favorite {
+  id: string
+  user_id: string
+  food_id: number
+  created_at: string
+}
+
+export interface PlannedMeal {
+  id: string
+  user_id: string
+  food_id: number
+  target_date: string
+  grams: number
+}

--- a/src/utils/categoryCleanup.ts
+++ b/src/utils/categoryCleanup.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import supabase from '@/lib/supabase';
 import { mapCategory } from './csvUtils';
 
 export interface CategoryCleanupResult {

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,6 +1,6 @@
 import { differenceInDays, differenceInWeeks, differenceInMonths } from 'date-fns'
 import { weightService, sleepService } from '@/services/supabaseServices'
-import { supabase } from '@/integrations/supabase/client'
+import supabase from '@/lib/supabase'
 import type { UserGoal } from '@/services/dynamicDataService'
 
 export async function calculateGoalProgress(goal: UserGoal): Promise<number> {


### PR DESCRIPTION
## Summary
- replace old Supabase client with v2 client
- add new Supabase types and hook for foods
- adjust services and hooks to use numeric food IDs
- add reusable `FoodCard` component
- update imports across the app

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612ad8d22483259bdc6f0994b3eda9