### PR TITLE
Render PlanManager on plans page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import Sidebar from '@/components/Sidebar';
 import MobileNavigation from '@/components/MobileNavigation';
 import MealPlanner from '@/components/MealPlanner';
+import PlanManager from '@/components/PlanManager';
 import FoodLibrary from '@/components/FoodLibrary';
 import ChatBot from '@/components/ChatBot';
 import ProgressPage from '@/components/ProgressPage';
@@ -79,7 +80,12 @@ const Index = () => {
           </div>
         );
       case 'plans':
-        return <MealPlanner />;
+        return (
+          <div className="space-y-6">
+            <PlanManager />
+            <MealPlanner />
+          </div>
+        );
       case 'foods':
         return <FoodLibrary />;
       case 'chat':


### PR DESCRIPTION
## Summary
- show PlanManager alongside MealPlanner
- import PlanManager on Index page

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686133f249cc8325babf8eae6db799e9