### PR TITLE
Implement food addition

### DIFF
--- a/src/components/AddFoodDialog.tsx
+++ b/src/components/AddFoodDialog.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useFoods } from '@/hooks/useFoods';
+import { plannedMealService } from '@/services/nutritionPlanService';
+import { useAuth } from '@/hooks/useAuth';
+import { useToast } from '@/hooks/use-toast';
+import type { FoodClean } from '@/types/supabase';
+
+interface AddFoodDialogProps {
+  open: boolean;
+  mealId: string;
+  mealName: string;
+  onClose: () => void;
+  onFoodAdded: () => void;
+}
+
+const AddFoodDialog = ({ open, mealId, mealName, onClose, onFoodAdded }: AddFoodDialogProps) => {
+  const [search, setSearch] = useState('');
+  const [quantity, setQuantity] = useState(100);
+  const { foods, loading } = useFoods({ search });
+  const { user } = useAuth();
+  const { toast } = useToast();
+
+  const handleAdd = async (food: FoodClean) => {
+    if (!user) return;
+    try {
+      await plannedMealService.addFoodToMeal(mealId, food.id, quantity);
+      toast({ title: 'Aliment ajouté', description: `${food.name_fr} ajouté à ${mealName}.` });
+      onFoodAdded();
+      onClose();
+    } catch (error) {
+      console.error('Error adding food to meal:', error);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={open ? onClose : undefined}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Ajouter un aliment à {mealName}</DialogTitle>
+        </DialogHeader>
+        <Input
+          placeholder="Rechercher un aliment..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="mb-4"
+        />
+        <div className="flex items-center space-x-2 mb-4">
+          <label className="text-sm">Quantité (g)</label>
+          <Input
+            type="number"
+            min={1}
+            value={quantity}
+            onChange={(e) => setQuantity(Number(e.target.value))}
+            className="w-24"
+          />
+        </div>
+        <div className="max-h-60 overflow-y-auto space-y-2">
+          {loading && <p>Chargement...</p>}
+          {!loading && foods.map((food) => (
+            <div key={food.id} className="flex items-center justify-between p-2 border rounded-md">
+              <div>
+                <p className="font-medium">{food.name_fr}</p>
+                <p className="text-xs text-gray-500">{food.kcal} kcal / 100g</p>
+              </div>
+              <Button size="sm" onClick={() => handleAdd(food)}>Ajouter</Button>
+            </div>
+          ))}
+          {!loading && foods.length === 0 && (
+            <p className="text-sm text-center text-gray-500">Aucun aliment trouvé.</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AddFoodDialog;

--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -28,7 +28,7 @@ interface MealCardProps {
   meal: Meal;
   isShowingMacros: boolean;
   onToggleMacros: (mealId: string) => void;
-  onAddFood: (mealName: string) => void;
+  onAddFood: (meal: Meal) => void;
 }
 
 const calculateMealTotals = (foods: Food[]) => {
@@ -73,7 +73,7 @@ const MealCard: React.FC<MealCardProps> = ({
             <TooltipTrigger asChild>
               <Button
                 className="bg-gradient-to-br from-[#3b0764] via-[#312e81] to-[#0f172a] text-white px-6 py-3 rounded-xl hover:brightness-110 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:scale-105"
-                onClick={() => onAddFood(meal.name)}
+                onClick={() => onAddFood(meal)}
               >
                 <Plus size={18} className="mr-2" />
                 <span className="hidden sm:inline font-medium">Ajouter</span>
@@ -99,7 +99,7 @@ const MealCard: React.FC<MealCardProps> = ({
             <p className="text-sm mb-4">Commencez par ajouter des aliments à votre repas</p>
             <Button
               className="bg-gradient-to-br from-[#3b0764] via-[#312e81] to-[#0f172a] text-white px-6 py-2 rounded-xl hover:brightness-110 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:scale-105"
-              onClick={() => onAddFood(meal.name)}
+              onClick={() => onAddFood(meal)}
             >
               <Plus size={16} className="mr-2" />
               Ajouter un aliment

--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from "@/hooks/use-toast";
 import { useNutritionPlan } from '@/hooks/useNutritionPlan';
 import MealCard from './MealCard';
+import AddFoodDialog from './AddFoodDialog';
 
 // Types pour les repas dynamiques
 interface Food {
@@ -28,8 +29,9 @@ interface Meal {
 
 const MealPlanner = () => {
   const { toast } = useToast();
-  const { activePlan, plannedMeals, loading } = useNutritionPlan();
+  const { activePlan, plannedMeals, loading, refreshPlan } = useNutritionPlan();
   const [showMacros, setShowMacros] = useState<string | null>(null);
+  const [mealToAddFood, setMealToAddFood] = useState<Meal | null>(null);
 
   // Transformer les repas planifiés en format attendu par MealCard
   const transformedMeals: Meal[] = plannedMeals.map(meal => ({
@@ -97,11 +99,8 @@ const MealPlanner = () => {
     });
   };
 
-  const handleAddFood = (mealName: string) => {
-    toast({
-      title: "Fonctionnalité à venir",
-      description: `L'ajout d'aliments à ${mealName} sera bientôt disponible.`,
-    });
+  const handleAddFood = (meal: Meal) => {
+    setMealToAddFood(meal);
   };
 
   if (loading) {
@@ -167,6 +166,15 @@ const MealPlanner = () => {
           />
         ))}
       </div>
+      {mealToAddFood && (
+        <AddFoodDialog
+          open={!!mealToAddFood}
+          mealId={mealToAddFood.id}
+          mealName={mealToAddFood.name}
+          onClose={() => setMealToAddFood(null)}
+          onFoodAdded={refreshPlan}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enable adding foods to meals from the foods_clean table
- pass the meal to the add-food handler in MealCard
- show AddFoodDialog from MealPlanner with search and quantity

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68616182177c8325a5965c4b3c84f165