### PR TITLE
Implement group selection in food dialog

### DIFF
--- a/src/components/AddFoodDialog.tsx
+++ b/src/components/AddFoodDialog.tsx
@@ -2,7 +2,9 @@ import React, { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useFoods } from '@/hooks/useFoods';
+import { useFoodGroups } from '@/hooks/useFoodGroups';
 import { plannedMealService } from '@/services/nutritionPlanService';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
@@ -19,7 +21,9 @@ interface AddFoodDialogProps {
 const AddFoodDialog = ({ open, mealId, mealName, onClose, onFoodAdded }: AddFoodDialogProps) => {
   const [search, setSearch] = useState('');
   const [quantity, setQuantity] = useState(100);
-  const { foods, loading } = useFoods({ search });
+  const [group, setGroup] = useState('');
+  const { groups } = useFoodGroups();
+  const { foods, loading } = useFoods({ search, group });
   const { user } = useAuth();
   const { toast } = useToast();
 
@@ -41,6 +45,17 @@ const AddFoodDialog = ({ open, mealId, mealName, onClose, onFoodAdded }: AddFood
         <DialogHeader>
           <DialogTitle>Ajouter un aliment à {mealName}</DialogTitle>
         </DialogHeader>
+        <Select value={group} onValueChange={setGroup}>
+          <SelectTrigger className="mb-4">
+            <SelectValue placeholder="Choisir un groupe" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">Tous</SelectItem>
+            {groups.map((g) => (
+              <SelectItem key={g} value={g}>{g}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
         <Input
           placeholder="Rechercher un aliment..."
           value={search}

--- a/src/hooks/useFoodGroups.ts
+++ b/src/hooks/useFoodGroups.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import supabase from '@/lib/supabase'
+
+export function useFoodGroups() {
+  const [groups, setGroups] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    ;(async () => {
+      setLoading(true)
+      const { data, error } = await supabase
+        .from('foods_clean')
+        .select('group_fr')
+        .limit(1000)
+      if (!mounted) return
+      if (error) {
+        setError(error.message)
+      } else {
+        const unique = Array.from(
+          new Set((data as any[]).map(d => d.group_fr).filter(Boolean))
+        ) as string[]
+        setGroups(unique)
+      }
+      setLoading(false)
+    })()
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  return { groups, loading, error }
+}

--- a/src/hooks/useFoods.ts
+++ b/src/hooks/useFoods.ts
@@ -6,11 +6,17 @@ const PAGE_SIZE = 20
 
 interface Params {
   search?: string
+  group?: string
   page?: number
   limit?: number
 }
 
-export function useFoods({ search = '', page = 0, limit = PAGE_SIZE }: Params) {
+export function useFoods({
+  search = '',
+  group = '',
+  page = 0,
+  limit = PAGE_SIZE
+}: Params) {
   const [foods, setFoods] = useState<FoodClean[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -28,6 +34,9 @@ export function useFoods({ search = '', page = 0, limit = PAGE_SIZE }: Params) {
       if (search) {
         query = query.ilike('name_fr', `%${search}%`)
       }
+      if (group) {
+        query = query.eq('group_fr', group)
+      }
       const { data, error } = await query
       if (!mounted) return
       if (error) {
@@ -40,7 +49,7 @@ export function useFoods({ search = '', page = 0, limit = PAGE_SIZE }: Params) {
     return () => {
       mounted = false
     }
-  }, [search, page, limit])
+  }, [search, group, page, limit])
 
   return { foods, loading, error }
 }


### PR DESCRIPTION
## Summary
- add hook to load food groups from Supabase
- extend `useFoods` with a group filter
- update `AddFoodDialog` UI with group selector

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616ddb8f748325906fc5a036325f6e