### PR TITLE
Fix meal planning queries

### DIFF
--- a/src/components/AddFoodDialog.tsx
+++ b/src/components/AddFoodDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -44,6 +44,7 @@ const AddFoodDialog = ({ open, mealId, mealName, onClose, onFoodAdded }: AddFood
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>Ajouter un aliment à {mealName}</DialogTitle>
+          <DialogDescription>Sélectionnez un aliment et la quantité à ajouter.</DialogDescription>
         </DialogHeader>
         <Select value={group} onValueChange={setGroup}>
           <SelectTrigger className="mb-4">


### PR DESCRIPTION
## Summary
- handle missing aria description for AddFoodDialog
- fetch meals and foods separately to avoid join errors
- fall back to `meal_id` column when adding foods

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861775a846083258a086343bfc76777