### PR TITLE
Update planned_meal_foods fields

### DIFF
--- a/src/api/meal.ts
+++ b/src/api/meal.ts
@@ -4,11 +4,17 @@ import type { PlannedMealFood } from '@/types/supabase'
 export async function addFoodToMeal(
   plannedMealId: string,
   foodId: number,
-  quantity: number
+  quantity: number,
+  targetDate?: string
 ): Promise<PlannedMealFood> {
   const { data, error } = await supabase
     .from('planned_meal_foods')
-    .insert({ planned_meal_id: plannedMealId, food_id: foodId, quantity })
+    .insert({
+      planned_meal_id: plannedMealId,
+      food_id: foodId,
+      grams: quantity,
+      target_date: targetDate
+    })
     .select()
     .single()
 

--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -42,11 +42,11 @@ const MealPlanner = () => {
     foods: meal.planned_meal_foods?.map((plannedFood: any) => ({
       id: plannedFood.id,
       name: plannedFood.foods?.name || 'Aliment inconnu',
-      calories: Math.round((plannedFood.foods?.calories || 0) * plannedFood.quantity / 100),
-      protein: Math.round((plannedFood.foods?.protein || 0) * plannedFood.quantity / 100 * 10) / 10,
-      carbs: Math.round((plannedFood.foods?.carbs || 0) * plannedFood.quantity / 100 * 10) / 10,
-      fat: Math.round((plannedFood.foods?.fat || 0) * plannedFood.quantity / 100 * 10) / 10,
-      quantity: plannedFood.quantity,
+      calories: Math.round((plannedFood.foods?.calories || 0) * plannedFood.grams / 100),
+      protein: Math.round((plannedFood.foods?.protein || 0) * plannedFood.grams / 100 * 10) / 10,
+      carbs: Math.round((plannedFood.foods?.carbs || 0) * plannedFood.grams / 100 * 10) / 10,
+      fat: Math.round((plannedFood.foods?.fat || 0) * plannedFood.grams / 100 * 10) / 10,
+      quantity: plannedFood.grams,
       unit: plannedFood.foods?.unit || 'g'
     })) || []
   }));

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -385,23 +385,26 @@ export type Database = {
         Row: {
           created_at: string | null
           food_id: string | null
+          grams: number
           id: string
           planned_meal_id: string | null
-          quantity: number
+          target_date: string | null
         }
         Insert: {
           created_at?: string | null
           food_id?: string | null
+          grams: number
           id?: string
           planned_meal_id?: string | null
-          quantity: number
+          target_date?: string | null
         }
         Update: {
           created_at?: string | null
           food_id?: string | null
+          grams?: number
           id?: string
           planned_meal_id?: string | null
-          quantity?: number
+          target_date?: string | null
         }
         Relationships: [
           {

--- a/src/services/nutritionPlanService.ts
+++ b/src/services/nutritionPlanService.ts
@@ -153,13 +153,19 @@ export const plannedMealService = {
     }
   },
 
-  async addFoodToMeal(plannedMealId: string, foodId: number, quantity: number) {
+  async addFoodToMeal(
+    plannedMealId: string,
+    foodId: number,
+    quantity: number,
+    targetDate?: string
+  ) {
     const { error } = await supabase
       .from('planned_meal_foods')
       .insert({
         planned_meal_id: plannedMealId,
         food_id: foodId,
-        quantity,
+        grams: quantity,
+        target_date: targetDate,
       });
 
     if (error) {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -43,6 +43,7 @@ export interface PlannedMealFood {
   id: string
   planned_meal_id: string
   food_id: number
-  quantity: number
+  grams: number
+  target_date?: string
   created_at: string
 }


### PR DESCRIPTION
## Summary
- adjust planned meal food schema types
- update supabase inserts for `grams`/`target_date`
- tweak meal planner to use grams

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686185781a6c8325909e0c2cde000a46