### PR TITLE
Simplify meal API insert

### DIFF
--- a/src/api/meals.ts
+++ b/src/api/meals.ts
@@ -1,5 +1,4 @@
 import supabase from '@/lib/supabase'
-import dayjs from 'dayjs'
 
 export interface PlannedMealFood {
   id: string
@@ -19,22 +18,14 @@ export async function addFoodToMeal(params: {
 }): Promise<void> {
   const { plannedMealId, foodId, grams, targetDate } = params
   try {
-    const {
-      data: { user },
-      error: authError
-    } = await supabase.auth.getUser()
-
-    if (authError || !user) {
-      throw 'Not authenticated'
-    }
-
-    const finalDate = targetDate ?? dayjs().format('YYYY-MM-DD')
     const insertData: Record<string, unknown> = {
       planned_meal_id: plannedMealId,
       food_id: foodId,
-      grams,
-      target_date: finalDate,
-      ...(user ? { user_id: user.id } : {})
+      grams
+    }
+
+    if (targetDate) {
+      insertData.target_date = targetDate
     }
 
     const { error } = await supabase.from('planned_meal_foods').insert(insertData)


### PR DESCRIPTION
## Summary
- simplify `addFoodToMeal` API to rely on Supabase defaults

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6864267afa90832592c1fe95e7d0cd95