### PR TITLE
Fix missing useEffect import

### DIFF
--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useToast } from "@/hooks/use-toast";


### PR DESCRIPTION
## Summary
- import `useEffect` in MealPlanner component

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686821ce48d8832598de7f1fd98684e2