### PR TITLE
Fix fetchMeals query parenthesis

### DIFF
--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -116,7 +116,9 @@ const MealPlanner = () => {
   const fetchMeals = async (id: string) => {
     const { data, error } = await supabase
       .from('planned_meals')
-      .select('id,name,meal_time,target_calories,planned_meal_foods(id,grams,foods(id,name,calories,protein,carbs,fat,unit)))')
+      .select(
+        'id,name,meal_time,target_calories,planned_meal_foods(id,grams,foods(id,name,calories,protein,carbs,fat,unit))'
+      )
       .eq('plan_id', id)
       .order('meal_order');
 


### PR DESCRIPTION
## Summary
- fix closing parenthesis in MealPlanner query

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868256450a88325bea6eb8eb0e95371