### PR TITLE
Fix meal planner query to match DB fields

### DIFF
--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -114,11 +114,11 @@ const MealPlanner = () => {
   };
 
   const fetchMeals = async (id: string) => {
-    const { data, error } = await supabase
-      .from('planned_meals')
-      .select(
-        'id,name,meal_time,target_calories,planned_meal_foods(id,grams,foods(id,name,calories,protein,carbs,fat,unit))'
-      )
+      const { data, error } = await supabase
+        .from('planned_meals')
+        .select(
+          'id,name,meal_time,target_calories,planned_meal_foods(id,grams,foods(id,name:name_fr,calories:kcal,protein:protein_g,carbs:carb_g,fat:fat_g,unit))'
+        )
       .eq('plan_id', id)
       .order('meal_order');
 


### PR DESCRIPTION
## Summary
- fix Supabase query for planned meals to request existing columns with aliases

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868281d268083258b3266e7905ca2cc