### PR TITLE
Add activity/sleep entries migrations and update schema

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -223,29 +223,29 @@ export type Database = {
       meal_entries: {
         Row: {
           created_at: string | null
-          date: string
+          eaten_at: string
           food_id: string
+          grams: number
           id: string
           meal_type: string
-          quantity: number
           user_id: string
         }
         Insert: {
           created_at?: string | null
-          date?: string
+          eaten_at?: string
           food_id: string
+          grams: number
           id?: string
           meal_type: string
-          quantity: number
           user_id: string
         }
         Update: {
           created_at?: string | null
-          date?: string
+          eaten_at?: string
           food_id?: string
+          grams?: number
           id?: string
           meal_type?: string
-          quantity?: number
           user_id?: string
         }
         Relationships: [

--- a/supabase/migrations/20250615074535-0f8221f4-8b41-4206-8a47-f6a17dc6f867.sql
+++ b/supabase/migrations/20250615074535-0f8221f4-8b41-4206-8a47-f6a17dc6f867.sql
@@ -65,9 +65,9 @@ CREATE TABLE public.meal_entries (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
   food_id UUID REFERENCES public.foods(id) ON DELETE CASCADE NOT NULL,
-  quantity DECIMAL(6,2) NOT NULL,
+  grams DECIMAL(6,2) NOT NULL,
   meal_type TEXT CHECK (meal_type IN ('breakfast', 'lunch', 'dinner', 'snack')) NOT NULL,
-  date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  eaten_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 

--- a/supabase/migrations/20250705074158-6dfd472f-1bd1-46db-a0ec-2e389d534aab.sql
+++ b/supabase/migrations/20250705074158-6dfd472f-1bd1-46db-a0ec-2e389d534aab.sql
@@ -1,0 +1,15 @@
+-- Create foods_clean view
+CREATE OR REPLACE VIEW public.foods_clean AS
+SELECT
+  id,
+  name AS name_fr,
+  category AS group_fr,
+  calories AS kcal,
+  protein AS protein_g,
+  carbs AS carb_g,
+  fat AS fat_g,
+  0 AS sugars_g,
+  fiber AS fiber_g,
+  0 AS sat_fat_g,
+  salt AS salt_g
+FROM public.foods;

--- a/supabase/migrations/20250705074158-e4a05015-fb17-4ef5-ab59-54ae181fa765.sql
+++ b/supabase/migrations/20250705074158-e4a05015-fb17-4ef5-ab59-54ae181fa765.sql
@@ -1,0 +1,18 @@
+-- Create sleep_entries table
+CREATE TABLE public.sleep_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+  hours_slept NUMERIC NOT NULL,
+  quality_score NUMERIC,
+  date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE public.sleep_entries ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies
+CREATE POLICY "Users can view their own sleep entries" ON public.sleep_entries
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can manage their own sleep entries" ON public.sleep_entries
+  FOR ALL USING (auth.uid() = user_id);

--- a/supabase/migrations/20250705074158-f61703b4-8af9-4e59-9a66-88d6364bb677.sql
+++ b/supabase/migrations/20250705074158-f61703b4-8af9-4e59-9a66-88d6364bb677.sql
@@ -1,0 +1,19 @@
+-- Create activity_entries table
+CREATE TABLE public.activity_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+  activity_type TEXT NOT NULL,
+  duration_minutes INTEGER NOT NULL,
+  calories_burned NUMERIC,
+  date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE public.activity_entries ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies
+CREATE POLICY "Users can view their own activity entries" ON public.activity_entries
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can manage their own activity entries" ON public.activity_entries
+  FOR ALL USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- create migrations for activity_entries and sleep_entries tables with RLS
- create foods_clean view
- rename quantity/date columns to grams/eaten_at in meal_entries
- regenerate Supabase types (manually updated due to CLI failure)

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d625a2e08325a35c97a9ac80e90b