### PR TITLE
Fix meal entry param

### DIFF
--- a/src/services/supabaseServices.ts
+++ b/src/services/supabaseServices.ts
@@ -196,7 +196,13 @@ export const mealService = {
     return data || [];
   },
 
-  async addMealEntry(userId: string, foodId: number, grams: number, eatenAt?: Date) {
+  async addMealEntry(
+    userId: string,
+    foodId: number,
+    grams: number,
+    mealType: 'breakfast' | 'lunch' | 'dinner' | 'snack',
+    eatenAt?: Date
+  ) {
     const { error } = await supabase
       .from('meal_entries')
       .insert({


### PR DESCRIPTION
## Summary
- fix `addMealEntry` signature in Supabase services to include `mealType`

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find '@eslint/js' module)*

------
https://chatgpt.com/codex/tasks/task_e_6868daa59b548325b9730dc87a7cc95e