### PR TITLE
Switch to foods_clean view

### DIFF
--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -117,7 +117,7 @@ const MealPlanner = () => {
       const { data, error } = await supabase
         .from('planned_meals')
         .select(
-          'id,name,meal_time,target_calories,planned_meal_foods(id,grams,foods(id,name:name_fr,calories:kcal,protein:protein_g,carbs:carb_g,fat:fat_g,unit))'
+          'id,name,meal_time,target_calories,planned_meal_foods(id,grams,foods:foods_clean(id,name:name_fr,calories:kcal,protein:protein_g,carbs:carb_g,fat:fat_g))'
         )
       .eq('plan_id', id)
       .order('meal_order');
@@ -138,7 +138,7 @@ const MealPlanner = () => {
           carbs: Math.round(((pf.foods?.carbs ?? 0) * pf.grams) / 100 * 10) / 10,
           fat: Math.round(((pf.foods?.fat ?? 0) * pf.grams) / 100 * 10) / 10,
           quantity: pf.grams,
-          unit: pf.foods?.unit ?? 'g',
+          unit: 'g',
         })) || [],
     }));
 

--- a/src/services/food/foodRepository.ts
+++ b/src/services/food/foodRepository.ts
@@ -1,16 +1,17 @@
 
 import supabase from '@/lib/supabase';
 import { Food, FoodInsert } from '@/types/food';
+import type { FoodClean } from '@/types/supabase';
 
 export class FoodRepository {
   async getAllFoods(): Promise<Food[]> {
     try {
       console.log('Fetching foods from Supabase...');
-      
+
       const { data: foods, error } = await supabase
-        .from('foods')
+        .from('foods_clean')
         .select('*')
-        .order('name');
+        .order('name_fr');
 
       if (error) {
         console.error('Error loading foods:', error);
@@ -23,7 +24,27 @@ export class FoodRepository {
       }
 
       console.log(`Raw foods count: ${foods.length}`);
-      return foods;
+      return (foods as FoodClean[]).map(f => ({
+        id: String(f.id),
+        name: f.name_fr,
+        category: f.group_fr,
+        calories: f.kcal,
+        protein: f.protein_g,
+        carbs: f.carb_g,
+        fat: f.fat_g,
+        fiber: f.fiber_g,
+        salt: f.salt_g,
+        unit: 'g',
+        image: null,
+        created_at: null,
+        calcium: null,
+        iron: null,
+        magnesium: null,
+        potassium: null,
+        sodium: null,
+        vitamin_c: null,
+        vitamin_d: null,
+      }));
     } catch (error) {
       console.error('Error in getAllFoods:', error);
       return [];

--- a/src/services/nutritionPlanService.ts
+++ b/src/services/nutritionPlanService.ts
@@ -114,7 +114,7 @@ export const plannedMealService = {
 
     const { data: mealFoods, error: foodsError } = await supabase
       .from('planned_meal_foods')
-      .select('*, foods(*)')
+      .select('*, foods:foods_clean(id,name:name_fr,calories:kcal,protein:protein_g,carbs:carb_g,fat:fat_g)')
       .in('planned_meal_id', meals.map((m) => m.id));
 
     if (foodsError) {

--- a/src/services/supabaseServices.ts
+++ b/src/services/supabaseServices.ts
@@ -7,6 +7,7 @@ type WeightEntry = Database['public']['Tables']['weight_entries']['Row'];
 type CalorieEntry = Database['public']['Tables']['calorie_entries']['Row'];
 type MealEntry = Database['public']['Tables']['meal_entries']['Row'];
 type Food = Database['public']['Tables']['foods']['Row'];
+import type { FoodClean } from '@/types/supabase';
 type HydrationEntry = Database['public']['Tables']['hydration_entries']['Row'];
 type UserSettings = Database['public']['Tables']['user_settings']['Row'];
 
@@ -113,15 +114,35 @@ export const calorieService = {
 export const foodService = {
   async getFoods(): Promise<Food[]> {
     const { data, error } = await supabase
-      .from('foods')
+      .from('foods_clean')
       .select('*')
-      .order('name');
-    
+      .order('name_fr');
+
     if (error) {
       console.error('Error fetching foods:', error);
       return [];
     }
-    return data || [];
+    return (data as FoodClean[]).map(f => ({
+      id: String(f.id),
+      name: f.name_fr,
+      category: f.group_fr,
+      calories: f.kcal,
+      protein: f.protein_g,
+      carbs: f.carb_g,
+      fat: f.fat_g,
+      fiber: f.fiber_g,
+      salt: f.salt_g,
+      unit: 'g',
+      image: null,
+      created_at: null,
+      calcium: null,
+      iron: null,
+      magnesium: null,
+      potassium: null,
+      sodium: null,
+      vitamin_c: null,
+      vitamin_d: null,
+    }));
   },
 
   async getUserFavorites(userId: string): Promise<number[]> {
@@ -172,7 +193,7 @@ export const mealService = {
       .from('meal_entries')
       .select(`
         *,
-        foods (*)
+        foods:foods_clean (*)
       `)
       .eq('user_id', userId);
 


### PR DESCRIPTION
## Summary
- read foods from the `foods_clean` view instead of the table
- map view columns back to existing `Food` type
- update planned meal fetches to join the view

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6868e14704f483258404e1bf0add9ee8