### PR TITLE
Fix planned meal food insertion

### DIFF
--- a/src/api/meals.ts
+++ b/src/api/meals.ts
@@ -4,7 +4,7 @@ export interface PlannedMealFood {
   id: string
   planned_meal_id: string
   user_id: string
-  food_id: number
+  food_id: string
   grams: number
   target_date: string
   created_at: string
@@ -12,12 +12,16 @@ export interface PlannedMealFood {
 
 export async function addFoodToMeal(params: {
   plannedMealId: string
-  foodId: number
+  foodId: string
   grams: number
   targetDate?: string
 }): Promise<void> {
   const { plannedMealId, foodId, grams, targetDate } = params
   try {
+    console.log('Planned meal ID:', plannedMealId)
+    if (!plannedMealId) {
+      throw new Error('Invalid planned meal ID')
+    }
     const insertData: Record<string, unknown> = {
       planned_meal_id: plannedMealId,
       food_id: foodId,

--- a/src/components/AddFoodDialog.tsx
+++ b/src/components/AddFoodDialog.tsx
@@ -27,7 +27,12 @@ const AddFoodDialog = ({ open, mealId, mealName, onClose, onAddFood }: AddFoodDi
   const handleAdd = async (food: FoodClean) => {
     try {
       await onAddFood(mealId, food.id, quantity);
-      toast({ title: 'Aliment ajouté', description: `${food.name_fr} ajouté à ${mealName}.` });
+      if (mealName) {
+        toast({ title: 'Aliment ajouté', description: `${food.name_fr} ajouté à ${mealName}.` });
+      } else {
+        console.error('mealName is undefined when adding food');
+        toast({ title: 'Aliment ajouté', description: `${food.name_fr} ajouté.` });
+      }
       onClose();
     } catch (error) {
       toast({

--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -168,7 +168,7 @@ const MealPlanner = () => {
 
       await addFoodToMeal({
         plannedMealId: dbMealId,
-        foodId: Number(foodId),
+        foodId,
         grams,
       });
 

--- a/src/services/nutritionPlanService.ts
+++ b/src/services/nutritionPlanService.ts
@@ -155,7 +155,7 @@ export const plannedMealService = {
 
   async addFoodToMeal(
     plannedMealId: string,
-    foodId: number,
+    foodId: string,
     quantity: number,
     targetDate?: string
   ) {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -3,7 +3,7 @@ import type { Database as GeneratedDatabase } from '@/integrations/supabase/type
 export type Database = GeneratedDatabase
 
 export interface FoodClean {
-  id: number
+  id: string
   name_fr: string
   group_fr: string
   kcal: number
@@ -19,7 +19,7 @@ export interface FoodClean {
 export interface MealEntry {
   id: string
   user_id: string
-  food_id: number
+  food_id: string
   grams: number
   eaten_at: string
 }
@@ -27,14 +27,14 @@ export interface MealEntry {
 export interface Favorite {
   id: string
   user_id: string
-  food_id: number
+  food_id: string
   created_at: string
 }
 
 export interface PlannedMeal {
   id: string
   user_id: string
-  food_id: number
+  food_id: string
   target_date: string
   grams: number
 }
@@ -43,7 +43,7 @@ export interface PlannedMealFood {
   id: string
   planned_meal_id: string
   user_id: string
-  food_id: number
+  food_id: string
   grams: number
   target_date: string
   created_at: string


### PR DESCRIPTION
## Summary
- fix addFoodToMeal call to keep string UUID
- log invalid meal IDs before inserting
- ensure AddFoodDialog checks for missing meal name
- update nutrition plan service and Supabase types

## Testing
- `npx tsc --noEmit`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690a7265b08325afc7b2f6c7e650a3