### PR TITLE
Fix AddFoodDialog meal name handling

### DIFF
--- a/src/components/AddFoodDialog.tsx
+++ b/src/components/AddFoodDialog.tsx
@@ -26,13 +26,18 @@ const AddFoodDialog = ({ open, mealId, mealName, onClose, onAddFood }: AddFoodDi
 
   const handleAdd = async (food: FoodClean) => {
     try {
-      await onAddFood(mealId, food.id, quantity);
-      if (mealName) {
-        toast({ title: 'Aliment ajouté', description: `${food.name_fr} ajouté à ${mealName}.` });
-      } else {
+      if (!mealName) {
         console.error('mealName is undefined when adding food');
-        toast({ title: 'Aliment ajouté', description: `${food.name_fr} ajouté.` });
+        toast({
+          title: 'Erreur',
+          description: 'Le repas cible est introuvable.',
+          variant: 'destructive'
+        });
+        return;
       }
+
+      await onAddFood(mealId, food.id, quantity);
+      toast({ title: 'Aliment ajouté', description: `${food.name_fr} ajouté à ${mealName}.` });
       onClose();
     } catch (error) {
       toast({

--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -109,8 +109,14 @@ const MealPlanner = () => {
     });
   };
 
-  const handleOpenAddFood = (meal: Meal) => {
-    setMealToAddFood(meal);
+  // Open the "Add food" dialog for the given meal
+  const handleOpenAddFood = (mealId: string) => {
+    const meal = displayMeals.find((m) => m.id === mealId);
+    if (meal) {
+      setMealToAddFood(meal);
+    } else {
+      console.error('Meal not found for id', mealId);
+    }
   };
 
   const fetchMeals = async (id: string) => {


### PR DESCRIPTION
## Summary
- resolve undefined `mealName` by looking up the meal from id
- warn user if `mealName` is missing before adding food

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686911a6f5548325bb30117e780dc3d6