### PR TITLE
Integrate Google Font Poppins

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />
 
+    <!-- Google Font: Poppins -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
+
     <meta property="og:title" content="nutri-flex-pal" />
     <meta property="og:description" content="Lovable Generated Project" />
     <meta property="og:type" content="website" />

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -53,7 +53,7 @@
   }
 
   body {
-    @apply bg-background text-foreground transition-all duration-300;
+    @apply font-sans bg-background text-foreground transition-all duration-300;
   }
 
   /* Smooth scrolling */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
+import defaultTheme from "tailwindcss/defaultTheme";
 
 export default {
 	darkMode: ["class"],
@@ -18,8 +19,11 @@ export default {
 				'2xl': '1400px'
 			}
 		},
-		extend: {
-			colors: {
+                extend: {
+                        fontFamily: {
+                                sans: ["Poppins", ...defaultTheme.fontFamily.sans],
+                        },
+                        colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',


### PR DESCRIPTION
## Summary
- add Google Font Poppins in index.html
- configure Poppins as default sans-serif font in Tailwind
- apply `font-sans` class on body

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68692af254a08325bb61a4f55d53a938