### PR TITLE
Connect meals with meal_types

### DIFF
--- a/src/api/meals.ts
+++ b/src/api/meals.ts
@@ -53,6 +53,15 @@ export async function createMeal(
   planId: string,
   mealType?: string
 ): Promise<string> {
+  // Retrieve meal_type_id from meal_types based on display name
+  const { data: typeData } = await supabase
+    .from('meal_types')
+    .select('id')
+    .eq('display_name', name)
+    .maybeSingle()
+
+  const mealTypeId = typeData?.id || null
+
   let target = kcal ?? 0
   if (kcal === undefined && mealType) {
     const { data: plan } = await supabase
@@ -71,6 +80,7 @@ export async function createMeal(
     .insert({
       name,
       meal_time: time,
+      meal_type_id: mealTypeId,
       target_calories: target,
       plan_id: planId
     })
@@ -92,6 +102,15 @@ export async function getOrCreatePlannedMeal(params: {
   targetCalories?: number
 }): Promise<string> {
   const { planId, name, mealTime, mealType, targetCalories } = params
+
+  // Retrieve meal_type_id from meal_types based on display name
+  const { data: typeData } = await supabase
+    .from('meal_types')
+    .select('id')
+    .eq('display_name', name)
+    .maybeSingle()
+
+  const mealTypeId = typeData?.id || null
 
   // Try to find existing meal for this plan, name and time
   const { data: existing, error } = await supabase
@@ -134,6 +153,7 @@ export async function getOrCreatePlannedMeal(params: {
     .insert({
       name,
       meal_time: mealTime,
+      meal_type_id: mealTypeId,
       target_calories: target,
       plan_id: planId
     })

--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -22,6 +22,7 @@ interface MealCardProps {
   mealId: string;
   name: string;
   time: string;
+  mealTypeId: string | null;
   kcalTarget: number;
   foods: Food[];
   isShowingMacros: boolean;
@@ -47,6 +48,7 @@ const MealCard: React.FC<MealCardProps> = ({
   mealId,
   name,
   time,
+  mealTypeId,
   kcalTarget,
   foods,
   isShowingMacros,
@@ -57,7 +59,7 @@ const MealCard: React.FC<MealCardProps> = ({
 }) => {
   const totals = calculateMealTotals(foods);
   const progress = (totals.calories / kcalTarget) * 100;
-  const mealIcon = useMealIcon(name);
+  const mealIcon = useMealIcon(mealTypeId || name);
   const { toast } = useToast();
   const lastItemRef = React.useRef<HTMLDivElement | null>(null);
 

--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -39,6 +39,7 @@ interface Meal {
   name: string;
   time: string;
   mealType: string;
+  mealTypeId: string | null;
   foods: Food[];
   targetCalories: number;
 }
@@ -99,6 +100,7 @@ const MealPlanner = () => {
       name: 'Petit-déjeuner',
       time: '08:00',
       mealType: 'breakfast',
+      mealTypeId: null,
       foods: [],
       targetCalories: 400
     },
@@ -107,6 +109,7 @@ const MealPlanner = () => {
       name: 'Déjeuner',
       time: '12:30',
       mealType: 'lunch',
+      mealTypeId: null,
       foods: [],
       targetCalories: 550
     },
@@ -115,6 +118,7 @@ const MealPlanner = () => {
       name: 'Collation',
       time: '16:00',
       mealType: 'snack',
+      mealTypeId: null,
       foods: [],
       targetCalories: 200
     },
@@ -123,6 +127,7 @@ const MealPlanner = () => {
       name: 'Dîner',
       time: '19:30',
       mealType: 'dinner',
+      mealTypeId: null,
       foods: [],
       targetCalories: 500
     }
@@ -158,7 +163,7 @@ const MealPlanner = () => {
       const { data, error } = await supabase
         .from('planned_meals')
         .select(
-          'id,name,meal_time,target_calories,planned_meal_foods(id,grams,foods:foods_clean(id,name:name_fr,calories:kcal,protein:protein_g,carbs:carb_g,fat:fat_g))'
+          'id,name,meal_time,target_calories,meal_type_id,planned_meal_foods(id,grams,foods:foods_clean(id,name:name_fr,calories:kcal,protein:protein_g,carbs:carb_g,fat:fat_g))'
         )
       .eq('plan_id', id)
       .order('meal_order');
@@ -170,6 +175,7 @@ const MealPlanner = () => {
       name: meal.name,
       time: meal.meal_time,
       mealType: nameToType[meal.name] || meal.name.toLowerCase(),
+      mealTypeId: meal.meal_type_id ?? null,
       targetCalories: meal.target_calories,
       foods:
         meal.planned_meal_foods?.map((pf: any) => ({
@@ -283,6 +289,7 @@ const MealPlanner = () => {
             mealId={meal.id}
             name={meal.name}
             time={meal.time}
+            mealTypeId={meal.mealTypeId}
             kcalTarget={meal.targetCalories}
             foods={meal.foods}
             isShowingMacros={showMacros === meal.id}

--- a/src/components/mealIcons.tsx
+++ b/src/components/mealIcons.tsx
@@ -58,7 +58,7 @@ const getMealIconFallback = (
 };
 
 // Fonction pour obtenir l'icône depuis la base de données (asynchrone)
-export const getMealIcon = async (mealTypeKey: string, size: number = 18, className?: string): Promise<React.ReactElement> => {
+export const getMealIcon = async (mealIdentifier: string, size: number = 18, className?: string): Promise<React.ReactElement> => {
   // Vérifier le cache
   const now = Date.now();
   if (!mealTypesCache || (now - cacheTimestamp) > CACHE_DURATION) {
@@ -68,14 +68,16 @@ export const getMealIcon = async (mealTypeKey: string, size: number = 18, classN
     } catch (error) {
       console.error('Error loading meal types:', error);
       // Fallback vers les icônes par défaut
-      return getMealIconFallback(mealTypeKey, size, className);
+      return getMealIconFallback(mealIdentifier, size, className);
     }
   }
 
   // Trouver le type de repas correspondant
-  const mealType = mealTypesCache.find(mt => mt.type_key === mealTypeKey);
+  const mealType = mealTypesCache.find(
+    mt => mt.id === mealIdentifier || mt.type_key === mealIdentifier || mt.display_name === mealIdentifier
+  );
   if (!mealType) {
-    return getMealIconFallback(mealTypeKey, size, className);
+    return getMealIconFallback(mealIdentifier, size, className);
   }
 
   // Obtenir l'icône correspondante
@@ -84,17 +86,17 @@ export const getMealIcon = async (mealTypeKey: string, size: number = 18, classN
 };
 
 // Hook pour utiliser les icônes de repas dans les composants React
-export const useMealIcon = (mealTypeKey: string) => {
-  const [icon, setIcon] = useState<React.ReactElement>(() => getMealIconFallback(mealTypeKey));
+export const useMealIcon = (mealIdentifier: string) => {
+  const [icon, setIcon] = useState<React.ReactElement>(() => getMealIconFallback(mealIdentifier));
 
   useEffect(() => {
     const loadIcon = async () => {
-      const iconElement = await getMealIcon(mealTypeKey);
+      const iconElement = await getMealIcon(mealIdentifier);
       setIcon(iconElement);
     };
-    
+
     loadIcon();
-  }, [mealTypeKey]);
+  }, [mealIdentifier]);
 
   return icon;
 };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -431,6 +431,7 @@ export type Database = {
           meal_time: string
           name: string
           plan_id: string | null
+          meal_type_id: string | null
           target_calories: number
         }
         Insert: {
@@ -440,6 +441,7 @@ export type Database = {
           meal_time: string
           name: string
           plan_id?: string | null
+          meal_type_id?: string | null
           target_calories: number
         }
         Update: {
@@ -449,6 +451,7 @@ export type Database = {
           meal_time?: string
           name?: string
           plan_id?: string | null
+          meal_type_id?: string | null
           target_calories?: number
         }
         Relationships: [
@@ -457,6 +460,13 @@ export type Database = {
             columns: ["plan_id"]
             isOneToOne: false
             referencedRelation: "nutrition_plans"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "planned_meals_meal_type_id_fkey"
+            columns: ["meal_type_id"]
+            isOneToOne: false
+            referencedRelation: "meal_types"
             referencedColumns: ["id"]
           },
         ]

--- a/supabase/migrations/20250706091710-e0190f3e-26b7-461a-a6c4-d5dd3cc371aa.sql
+++ b/supabase/migrations/20250706091710-e0190f3e-26b7-461a-a6c4-d5dd3cc371aa.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.planned_meals
+  ADD COLUMN meal_type_id UUID REFERENCES public.meal_types(id);
+
+-- Update existing rows by matching meal name to meal type display name
+UPDATE public.planned_meals pm
+SET meal_type_id = mt.id
+FROM public.meal_types mt
+WHERE pm.name = mt.display_name;


### PR DESCRIPTION
## Summary
- add migration adding `meal_type_id` to `planned_meals`
- store meal type id when creating meals
- load the id in `MealPlanner` and forward it to `MealCard`
- update icon helpers to resolve icons by id
- extend Supabase types with the new column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a3b86f9b08325b665340c07fddcf0