### PR TITLE
Add gender field to profiles

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -461,6 +461,7 @@ export type Database = {
           created_at: string | null
           daily_calories: number | null
           email: string
+          gender: string | null
           fat_goal: number | null
           height: number | null
           id: string
@@ -477,6 +478,7 @@ export type Database = {
           created_at?: string | null
           daily_calories?: number | null
           email: string
+          gender?: string | null
           fat_goal?: number | null
           height?: number | null
           id: string
@@ -493,6 +495,7 @@ export type Database = {
           created_at?: string | null
           daily_calories?: number | null
           email?: string
+          gender?: string | null
           fat_goal?: number | null
           height?: number | null
           id?: string

--- a/supabase/migrations/20250712185000-b5d219a6-4d35-47b5-8bbd-34833efad974.sql
+++ b/supabase/migrations/20250712185000-b5d219a6-4d35-47b5-8bbd-34833efad974.sql
@@ -1,0 +1,3 @@
+-- Add gender column to profiles
+ALTER TABLE public.profiles
+  ADD COLUMN gender TEXT CHECK (gender IN ('male','female'));


### PR DESCRIPTION
## Summary
- add migration introducing nullable gender column to `public.profiles`
- update generated Supabase types with new `gender` field

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6872accd8b888325b848c27dc87e769f