### PR TITLE
Remove unused UserGoal interface

### DIFF
--- a/src/services/nutritionAdviceService.ts
+++ b/src/services/nutritionAdviceService.ts
@@ -10,11 +10,6 @@ interface UserProfile {
   activity_level: ActivityLevel;
 }
 
-interface UserGoal {
-  target_value: number | null;
-  description: string | null;
-}
-
 const activityFactor: Record<ActivityLevel, number> = {
   sedentary: 1.2,
   light: 1.375,


### PR DESCRIPTION
## Summary
- delete `UserGoal` interface from `nutritionAdviceService`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872acd0c6d8832591a97c1de4e2d91a