### PR TITLE
Add gender field to UserProfile schema

### DIFF
--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -37,6 +37,7 @@ const ProfilePage = ({ onManageGoals }: ProfilePageProps) => {
     age: '',
     weight: '',
     height: '',
+    gender: 'male',
     activityLevel: 'sédentaire',
     goal: 'maintien',
     bio: '',
@@ -79,6 +80,7 @@ const ProfilePage = ({ onManageGoals }: ProfilePageProps) => {
         age: storedProfile.age?.toString() || '',
         weight: storedProfile.weight?.toString() || '',
         height: storedProfile.height?.toString() || '',
+        gender: storedProfile.gender || 'male',
         activityLevel: activityMap[storedProfile.activity_level || 'sedentary'],
         goal: 'maintien',
         bio: '',
@@ -112,6 +114,8 @@ const ProfilePage = ({ onManageGoals }: ProfilePageProps) => {
       updates.weight = Number(value) || null;
     } else if (field === 'height') {
       updates.height = Number(value) || null;
+    } else if (field === 'gender') {
+      updates.gender = value;
     } else if (field === 'activityLevel') {
       updates.activity_level = reverseActivityMap[value] || 'sedentary';
     }
@@ -178,6 +182,7 @@ const ProfilePage = ({ onManageGoals }: ProfilePageProps) => {
     await updateProfile({
       name: `${p.firstName} ${p.lastName}`.trim(),
       email: p.email,
+      gender: p.gender,
       age: Number(p.age) || null,
       weight: Number(p.weight) || null,
       height: Number(p.height) || null,

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -13,6 +13,7 @@ export const UserProfileSchema = z.object({
   id: z.string(),
   name: z.string(),
   email: z.string().email(),
+  gender: z.enum(['male', 'female']),
   age: z.number().int().min(0),
   weight: z.number(),
   height: z.number(),


### PR DESCRIPTION
## Summary
- extend `UserProfileSchema` with `gender`
- propagate gender state into `ProfilePage`

## Testing
- `npx vitest run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873696218bc83258deb38a7849dcae9