### PR TITLE
Add gender field and resolve lint warnings

### DIFF
--- a/src/components/GoalsProgress.tsx
+++ b/src/components/GoalsProgress.tsx
@@ -49,7 +49,7 @@ const GoalsProgress = () => {
     } finally {
       setLoading(false);
     }
-  }, [user, toast]);
+  }, [user, toast, recalculateCalorieTarget]);
 
   useEffect(() => {
     loadGoals();

--- a/src/components/MealPlanner.tsx
+++ b/src/components/MealPlanner.tsx
@@ -95,7 +95,7 @@ const MealPlanner = () => {
       }
     };
     load();
-  }, [user]);
+  }, [user, toast]);
 
   // Repas par défaut si aucun plan actif
   const defaultMeals: Meal[] = [

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -15,6 +15,18 @@ import { useToast } from '@/hooks/use-toast';
 import ProfileSkeleton from './skeletons/ProfileSkeleton';
 import { useProfileValidation } from '@/hooks/useProfileValidation';
 
+const activityMap: Record<string, string> = {
+  sedentary: 'sédentaire',
+  light: 'légère',
+  moderate: 'modérée',
+  active: 'intense',
+  very_active: 'très intense',
+};
+
+const reverseActivityMap = Object.fromEntries(
+  Object.entries(activityMap).map(([k, v]) => [v, k])
+) as Record<string, string>;
+
 interface ProfilePageProps {
   onManageGoals?: () => void;
 }
@@ -43,18 +55,6 @@ const ProfilePage = ({ onManageGoals }: ProfilePageProps) => {
     bio: '',
   });
   const initialProfileRef = useRef<typeof profile | null>(null);
-
-  const activityMap: Record<string, string> = {
-    sedentary: 'sédentaire',
-    light: 'légère',
-    moderate: 'modérée',
-    active: 'intense',
-    very_active: 'très intense',
-  };
-
-  const reverseActivityMap = Object.fromEntries(
-    Object.entries(activityMap).map(([k, v]) => [v, k])
-  ) as Record<string, string>;
 
   const loadGoals = useCallback(async () => {
     if (!user) return;
@@ -172,7 +172,8 @@ const ProfilePage = ({ onManageGoals }: ProfilePageProps) => {
     const height = Number(profile.height);
     const age = Number(profile.age);
     if (!weight || !height || !age) return 0;
-    return 10 * weight + 6.25 * height - 5 * age;
+    const base = 10 * weight + 6.25 * height - 5 * age;
+    return base + (profile.gender === 'male' ? 5 : -161);
   };
 
   const handleResetProfile = async () => {
@@ -366,6 +367,19 @@ const ProfilePage = ({ onManageGoals }: ProfilePageProps) => {
                 error={errors.height}
               />
               </div>
+            </div>
+
+            <div>
+              <Label htmlFor="gender">Sexe</Label>
+              <select
+                id="gender"
+                value={profile.gender}
+                onChange={(e) => handleInputChange('gender', e.target.value)}
+                className="w-full h-10 px-3 py-2 border border-input bg-background rounded-md text-sm"
+              >
+                <option value="male">Homme</option>
+                <option value="female">Femme</option>
+              </select>
             </div>
 
             <div>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -11,6 +11,7 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => {
   const context = useContext(ThemeContext);
   if (context === undefined) {

--- a/src/components/WeightEntrySection.tsx
+++ b/src/components/WeightEntrySection.tsx
@@ -15,15 +15,15 @@ const WeightEntrySection = () => {
   const [entries, setEntries] = useState<WeightEntry[]>([]);
   const [suggestion, setSuggestion] = useState<string>('');
 
-  const loadEntries = async () => {
+  const loadEntries = React.useCallback(async () => {
     if (!user) return;
     const data = await weightService.getWeightEntries(user.id);
     setEntries(data);
-  };
+  }, [user]);
 
   useEffect(() => {
     loadEntries();
-  }, [user]);
+  }, [loadEntries]);
 
   useEffect(() => {
     if (entries.length > 0) {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -2,6 +2,8 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
+/* eslint-disable react-refresh/only-export-components */
+
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,6 +2,8 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
+/* eslint-disable react-refresh/only-export-components */
+
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"
+
+/* eslint-disable react-refresh/only-export-components */
 import {
   Controller,
   ControllerProps,

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { cva } from "class-variance-authority"
+
+/* eslint-disable react-refresh/only-export-components */
 import { ChevronDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
+
+/* eslint-disable react-refresh/only-export-components */
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,6 +1,8 @@
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, toast } from "sonner"
 
+/* eslint-disable react-refresh/only-export-components */
+
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
 const Toaster = ({ ...props }: ToasterProps) => {

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -2,6 +2,8 @@ import * as React from "react"
 import * as TogglePrimitive from "@radix-ui/react-toggle"
 import { cva, type VariantProps } from "class-variance-authority"
 
+/* eslint-disable react-refresh/only-export-components */
+
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -4,6 +4,8 @@ import { User, Session, AuthError } from '@supabase/supabase-js';
 import supabase from '@/lib/supabase';
 import { useToast } from '@/hooks/use-toast';
 
+/* eslint-disable react-refresh/only-export-components */
+
 interface AuthContextType {
   user: User | null;
   session: Session | null;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -11,7 +11,6 @@ const url = import.meta.env.VITE_SUPABASE_URL || DEFAULT_URL
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY || DEFAULT_KEY
 
 if (!import.meta.env.VITE_SUPABASE_URL || !import.meta.env.VITE_SUPABASE_ANON_KEY) {
-  // eslint-disable-next-line no-console
   console.warn('Supabase environment variables missing, falling back to default credentials.')
 }
 


### PR DESCRIPTION
## Summary
- add gender management to ProfilePage
- fix BMR calculation using gender
- resolve React hook dependency warnings
- silence react-refresh warnings
- clean unused ESLint directive

## Testing
- `npm run lint`
- `npm test -- -t ''`

------
https://chatgpt.com/codex/tasks/task_e_68736f8571948325b76115cb9be8bdd9