### PR TITLE
Switch nutrition advice model to DeepSeek

### DIFF
--- a/src/services/nutritionAdviceService.ts
+++ b/src/services/nutritionAdviceService.ts
@@ -46,7 +46,9 @@ export async function generateNutritionAdvice(userId: string): Promise<string> {
       'X-Title': 'NutriFlex',
     },
     body: JSON.stringify({
-      model: 'openai/gpt-4o',
+      // Utiliser le même modèle que pour le chat afin de rester cohérent
+      // avec le reste de l'application
+      model: 'deepseek/deepseek-r1-0528:free',
       messages: [
         { role: 'system', content: 'Tu es un expert nutritionniste et coach motivationnel.' },
         { role: 'user', content: prompt },


### PR DESCRIPTION
## Summary
- use DeepSeek model for nutrition advice like the chat service

## Testing
- `npm run lint`
- `npm test` (no test files found)

------
https://chatgpt.com/codex/tasks/task_e_68738df4dd1c8325897235da7f357278