### PR TITLE
Add food journal service

### DIFF
--- a/src/services/foodJournalService.ts
+++ b/src/services/foodJournalService.ts
@@ -1,0 +1,58 @@
+import supabase from '@/lib/supabase';
+import type { Database } from '@/types/supabase';
+
+// Database row types
+type ConsumedMealFood = Database['public']['Tables']['consumed_meal_foods']['Row'];
+type FoodClean = Database['public']['Views']['foods_clean']['Row'];
+type MealType = Database['public']['Tables']['meal_types']['Row'];
+type DailySummary = Database['public']['Views']['daily_nutrition_summary']['Row'];
+
+export const foodJournalService = {
+  async getTodayMeals(userId: string) {
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+    const endOfDay = new Date();
+    endOfDay.setHours(23, 59, 59, 999);
+
+    const { data, error } = await supabase
+      .from('consumed_meal_foods')
+      .select(
+        `*,
+        food:foods_clean (*),
+        meal_type:meal_types (*)
+      `
+      )
+      .eq('user_id', userId)
+      .gte('consumed_at', startOfDay.toISOString())
+      .lte('consumed_at', endOfDay.toISOString())
+      .order('consumed_at', { ascending: false });
+
+    if (error) {
+      console.error('Error fetching today meals:', error);
+      return [] as (ConsumedMealFood & { food: FoodClean; meal_type: MealType })[];
+    }
+    return (data || []) as (ConsumedMealFood & {
+      food: FoodClean;
+      meal_type: MealType;
+    })[];
+  },
+
+  async getDailySummary(userId: string, date: Date) {
+    const targetDate = new Date(date);
+    targetDate.setHours(0, 0, 0, 0);
+
+    const { data, error } = await supabase
+      .from('daily_nutrition_summary')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('summary_date', targetDate.toISOString().split('T')[0])
+      .maybeSingle();
+
+    if (error) {
+      console.error('Error fetching daily summary:', error);
+      return null as DailySummary | null;
+    }
+
+    return data as DailySummary | null;
+  }
+};


### PR DESCRIPTION
## Summary
- create `foodJournalService` with methods to fetch today's meals and a daily summary

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873e8a7f6848325907d69a0a035c335