### PR TITLE
Add FoodJournal route and navigation

### DIFF
--- a/src/components/FoodJournal.tsx
+++ b/src/components/FoodJournal.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { foodJournalService } from '@/services/foodJournalService';
+import { useAuth } from '@/hooks/useAuth';
+
+const FoodJournal = () => {
+  const { user } = useAuth();
+  const [meals, setMeals] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadMeals = async () => {
+      if (!user) return;
+      const data = await foodJournalService.getTodayMeals(user.id);
+      setMeals(data);
+      setLoading(false);
+    };
+    loadMeals();
+  }, [user]);
+
+  if (loading) {
+    return <div>Chargement...</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        Journal Alimentaire
+      </h1>
+      {meals.length === 0 ? (
+        <p className="text-gray-600 dark:text-gray-400">
+          Aucun repas enregistré aujourd\'hui.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {meals.map((meal) => (
+            <li
+              key={meal.id}
+              className="p-4 bg-white dark:bg-gray-800 rounded-lg shadow"
+            >
+              <div className="font-semibold">{meal.food.name_fr}</div>
+              <div className="text-sm text-gray-600 dark:text-gray-400">
+                {meal.grams}g - {meal.meal_type?.name_fr || meal.meal_type?.name}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default FoodJournal;

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Home, Book, Target, TrendingUp, User, MessageCircle } from 'lucide-react';
+import { Home, Book, Target, TrendingUp, User, MessageCircle, BookOpen } from 'lucide-react';
 
 interface MobileNavigationProps {
   activeSection: string;
@@ -14,12 +14,13 @@ const MobileNavigation = ({ activeSection, onSectionChange }: MobileNavigationPr
     { id: 'plans', label: 'Plans', icon: Target },
     { id: 'chat', label: 'Assistant', icon: MessageCircle },
     { id: 'progress', label: 'Progrès', icon: TrendingUp },
+    { id: 'journal', label: 'Journal', icon: BookOpen },
     { id: 'profile', label: 'Profil', icon: User },
   ];
 
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700 z-50 md:hidden shadow-2xl">
-      <div className="grid grid-cols-6 h-20">
+      <div className="grid grid-cols-7 h-20">
         {navItems.map((item) => {
           const Icon = item.icon;
           const isActive = activeSection === item.id;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Home, Target, Book, User, Settings, TrendingUp, MessageCircle, Sparkles, Shield } from 'lucide-react';
+import { Home, Target, Book, User, Settings, TrendingUp, MessageCircle, Sparkles, Shield, BookOpen } from 'lucide-react';
 import { useRole } from '@/hooks/useRole';
 
 interface SidebarProps {
@@ -17,6 +17,7 @@ const Sidebar = ({ activeSection, onSectionChange }: SidebarProps) => {
     { id: 'foods', label: 'Bibliothèque', icon: Book },
     { id: 'chat', label: 'Assistant IA', icon: MessageCircle },
     { id: 'progress', label: 'Progression', icon: TrendingUp },
+    { id: 'journal', label: 'Journal', icon: BookOpen },
     { id: 'profile', label: 'Profil', icon: User },
     { id: 'settings', label: 'Paramètres', icon: Settings },
   ];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,6 +11,7 @@ import ProfilePage from '@/components/ProfilePage';
 import SettingsPage from '@/components/SettingsPage';
 import AdminPanel from '@/components/AdminPanel';
 import AdminRoute from '@/components/AdminRoute';
+import FoodJournal from '@/components/FoodJournal';
 import NutritionStats from '@/components/NutritionStats';
 import DashboardGoals from '@/components/DashboardGoals';
 import CaloriesChart from '@/components/CaloriesChart';
@@ -92,6 +93,8 @@ const Index = () => {
         return <ChatBot />;
       case 'progress':
         return <ProgressPage />;
+      case 'journal':
+        return <FoodJournal />;
       case 'profile':
         return <ProfilePage onManageGoals={() => setActiveSection('progress')} />;
       case 'settings':


### PR DESCRIPTION
## Summary
- create **FoodJournal** component for viewing meals
- import and render FoodJournal in the main Index page
- add Journal entry in sidebar and mobile navigation

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873ef017bb083259d500f453ecad296