### PR TITLE
Centralise les formules de calcul nutritionnel

### DIFF
--- a/src/components/CreatePlanModal.tsx
+++ b/src/components/CreatePlanModal.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { generateNutritionTargets } from '@/utils/nutritionUtils';
 
 interface CreatePlanModalProps {
   open: boolean;
@@ -23,14 +24,15 @@ interface CreatePlanModalProps {
 }
 
 const CreatePlanModal = ({ open, onClose, onCreatePlan }: CreatePlanModalProps) => {
+  const defaultTargets = generateNutritionTargets(2200, 'maintenance');
   const [formData, setFormData] = useState({
     name: '',
     description: '',
     type: 'maintenance' as 'weight-loss' | 'maintenance' | 'bulk',
-    targetCalories: 2200,
-    targetProtein: 100,
-    targetCarbs: 250,
-    targetFat: 70,
+    targetCalories: defaultTargets.calories,
+    targetProtein: defaultTargets.protein,
+    targetCarbs: defaultTargets.carbs,
+    targetFat: defaultTargets.fat,
     duration: 8
   });
 
@@ -44,14 +46,15 @@ const CreatePlanModal = ({ open, onClose, onCreatePlan }: CreatePlanModalProps) 
       isActive: false
     });
     onClose();
+    const reset = generateNutritionTargets(2200, 'maintenance');
     setFormData({
       name: '',
       description: '',
       type: 'maintenance',
-      targetCalories: 2200,
-      targetProtein: 100,
-      targetCarbs: 250,
-      targetFat: 70,
+      targetCalories: reset.calories,
+      targetProtein: reset.protein,
+      targetCarbs: reset.carbs,
+      targetFat: reset.fat,
       duration: 8
     });
   };

--- a/src/hooks/useNutritionStats.ts
+++ b/src/hooks/useNutritionStats.ts
@@ -2,6 +2,7 @@
 import { useMemo } from 'react';
 import { useFoodStore } from '../stores/useFoodStore';
 import { useAppStore } from '../stores/useAppStore';
+import { generateNutritionTargets } from '../utils/nutritionUtils';
 
 export const useNutritionStats = () => {
   const { getTodayNutrition } = useFoodStore();
@@ -11,11 +12,12 @@ export const useNutritionStats = () => {
     const todayNutrition = getTodayNutrition();
     
     // Objectifs par défaut si pas d'utilisateur
+    const defaults = generateNutritionTargets(2200, 'maintenance');
     const defaultGoals = {
-      dailyCalories: 2200,
-      protein: 120,
-      carbs: 275,
-      fat: 75
+      dailyCalories: defaults.calories,
+      protein: defaults.protein,
+      carbs: defaults.carbs,
+      fat: defaults.fat
     };
 
     const goals = user?.goals || defaultGoals;

--- a/src/services/nutritionAdviceService.ts
+++ b/src/services/nutritionAdviceService.ts
@@ -1,5 +1,6 @@
 import supabase from '@/lib/supabase';
-import { calculateTDEE } from '@/utils/calorieUtils';
+import { calculateTDEE } from '@/utils/nutritionUtils';
+import type { UserProfile } from '@/schemas';
 
 export async function generateNutritionAdvice(userId: string): Promise<string> {
   // Étape 1 : récupérer le profil utilisateur et son objectif principal
@@ -22,13 +23,25 @@ export async function generateNutritionAdvice(userId: string): Promise<string> {
     .limit(1)
     .maybeSingle();
 
-  const tdee = calculateTDEE({
+  const userProfile: UserProfile = {
+    id: userId,
+    name: '',
+    email: '',
     gender: profile.gender,
+    age: profile.age,
     weight: profile.weight,
     height: profile.height,
-    age: profile.age,
     activityLevel: profile.activity_level,
-  });
+    goals: {
+      weightTarget: 0,
+      dailyCalories: 0,
+      protein: 0,
+      carbs: 0,
+      fat: 0,
+    },
+  };
+
+  const tdee = calculateTDEE(userProfile);
 
   // Étape 3 : construire le prompt
   const prompt = `Voici le profil de l'utilisateur :\n- Sexe : ${profile.gender}\n- Âge : ${profile.age} ans\n- Poids : ${profile.weight} kg\n- Taille : ${profile.height} cm\n- Niveau d'activité : ${profile.activity_level}\n- Objectif : ${goal?.target_value ? `${goal.target_value} kg` : 'non précisé'}\n- Description de l'objectif : ${goal?.description || 'non précisée'}\n\nSon TDEE estimé est de ${tdee} kcal par jour. Donne-lui des conseils nutritionnels personnalisés et motivants pour atteindre son objectif.`;

--- a/src/utils/nutritionUtils.ts
+++ b/src/utils/nutritionUtils.ts
@@ -1,0 +1,42 @@
+export type ActivityLevel = 'sedentary' | 'light' | 'moderate' | 'active' | 'very_active'
+
+import type { UserProfile } from '@/schemas'
+
+const activityFactor: Record<ActivityLevel, number> = {
+  sedentary: 1.2,
+  light: 1.375,
+  moderate: 1.55,
+  active: 1.725,
+  very_active: 1.9,
+}
+
+export function calculateTDEE(user: UserProfile): number {
+  const base = 10 * user.weight + 6.25 * user.height - 5 * user.age
+  const bmr = user.gender === 'male' ? base + 5 : base - 161
+  return Math.round(bmr * activityFactor[user.activityLevel])
+}
+
+export function generateNutritionTargets(
+  tdee: number,
+  goalType: 'weight-loss' | 'maintenance' | 'muscle-gain'
+) {
+  let calories = tdee
+  if (goalType === 'weight-loss') {
+    calories = Math.max(1200, tdee - 500)
+  } else if (goalType === 'muscle-gain') {
+    calories = tdee + 500
+  }
+
+  const ratios = {
+    'weight-loss': { p: 0.3, c: 0.4, f: 0.3 },
+    maintenance: { p: 0.25, c: 0.5, f: 0.25 },
+    'muscle-gain': { p: 0.3, c: 0.5, f: 0.2 },
+  } as const
+
+  const r = ratios[goalType]
+  const protein = Math.round((calories * r.p) / 4)
+  const fat = Math.round((calories * r.f) / 9)
+  const carbs = Math.max(0, Math.round((calories - protein * 4 - fat * 9) / 4))
+
+  return { calories, protein, carbs, fat }
+}


### PR DESCRIPTION
## Résumé
- ajoute un utilitaire `nutritionUtils.ts` avec `calculateTDEE` et `generateNutritionTargets`
- utilise ces fonctions pour générer le plan par défaut
- applique `generateNutritionTargets` aux valeurs par défaut du formulaire de création de plan
- calcule les objectifs par défaut via `generateNutritionTargets`
- adapte le service de conseils nutritionnels

## Tests
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874e60e1858832580eb0a9e4060ba8c