### PR TITLE
Fix NaN input values

### DIFF
--- a/src/components/CreatePlanModal.tsx
+++ b/src/components/CreatePlanModal.tsx
@@ -128,8 +128,13 @@ const CreatePlanModal = ({ open, onClose, onCreatePlan }: CreatePlanModalProps) 
                   type="number"
                   min="1"
                   max="52"
-                  value={formData.duration}
-                  onChange={(e) => setFormData({ ...formData, duration: parseInt(e.target.value) })}
+                  value={formData.duration || ''}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      duration: parseInt(e.target.value, 10) || 0,
+                    })
+                  }
                   required
                 />
               </div>
@@ -153,8 +158,13 @@ const CreatePlanModal = ({ open, onClose, onCreatePlan }: CreatePlanModalProps) 
                     type="number"
                     min="1000"
                     max="5000"
-                    value={formData.targetCalories}
-                    onChange={(e) => setFormData({ ...formData, targetCalories: parseInt(e.target.value) })}
+                    value={formData.targetCalories || ''}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        targetCalories: parseInt(e.target.value, 10) || 0,
+                      })
+                    }
                     required
                   />
                 </div>
@@ -166,8 +176,13 @@ const CreatePlanModal = ({ open, onClose, onCreatePlan }: CreatePlanModalProps) 
                     type="number"
                     min="50"
                     max="300"
-                    value={formData.targetProtein}
-                    onChange={(e) => setFormData({ ...formData, targetProtein: parseInt(e.target.value) })}
+                    value={formData.targetProtein || ''}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        targetProtein: parseInt(e.target.value, 10) || 0,
+                      })
+                    }
                     required
                   />
                 </div>
@@ -179,8 +194,13 @@ const CreatePlanModal = ({ open, onClose, onCreatePlan }: CreatePlanModalProps) 
                     type="number"
                     min="50"
                     max="500"
-                    value={formData.targetCarbs}
-                    onChange={(e) => setFormData({ ...formData, targetCarbs: parseInt(e.target.value) })}
+                    value={formData.targetCarbs || ''}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        targetCarbs: parseInt(e.target.value, 10) || 0,
+                      })
+                    }
                     required
                   />
                 </div>
@@ -192,8 +212,13 @@ const CreatePlanModal = ({ open, onClose, onCreatePlan }: CreatePlanModalProps) 
                     type="number"
                     min="20"
                     max="200"
-                    value={formData.targetFat}
-                    onChange={(e) => setFormData({ ...formData, targetFat: parseInt(e.target.value) })}
+                    value={formData.targetFat || ''}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        targetFat: parseInt(e.target.value, 10) || 0,
+                      })
+                    }
                     required
                   />
                 </div>

--- a/src/components/EditPlanModal.tsx
+++ b/src/components/EditPlanModal.tsx
@@ -128,8 +128,13 @@ const EditPlanModal = ({ open, onClose, plan, onUpdatePlan }: EditPlanModalProps
                   type="number"
                   min="1"
                   max="52"
-                  value={formData.duration}
-                  onChange={(e) => setFormData({ ...formData, duration: parseInt(e.target.value) })}
+                  value={formData.duration || ''}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      duration: parseInt(e.target.value, 10) || 0,
+                    })
+                  }
                   required
                 />
               </div>
@@ -147,8 +152,13 @@ const EditPlanModal = ({ open, onClose, plan, onUpdatePlan }: EditPlanModalProps
                     type="number"
                     min="1000"
                     max="5000"
-                    value={formData.target_calories}
-                    onChange={(e) => setFormData({ ...formData, target_calories: parseInt(e.target.value) })}
+                    value={formData.target_calories || ''}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        target_calories: parseInt(e.target.value, 10) || 0,
+                      })
+                    }
                     required
                   />
                 </div>
@@ -160,8 +170,13 @@ const EditPlanModal = ({ open, onClose, plan, onUpdatePlan }: EditPlanModalProps
                     type="number"
                     min="50"
                     max="300"
-                    value={formData.target_protein}
-                    onChange={(e) => setFormData({ ...formData, target_protein: parseInt(e.target.value) })}
+                    value={formData.target_protein || ''}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        target_protein: parseInt(e.target.value, 10) || 0,
+                      })
+                    }
                     required
                   />
                 </div>
@@ -173,8 +188,13 @@ const EditPlanModal = ({ open, onClose, plan, onUpdatePlan }: EditPlanModalProps
                     type="number"
                     min="50"
                     max="500"
-                    value={formData.target_carbs}
-                    onChange={(e) => setFormData({ ...formData, target_carbs: parseInt(e.target.value) })}
+                    value={formData.target_carbs || ''}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        target_carbs: parseInt(e.target.value, 10) || 0,
+                      })
+                    }
                     required
                   />
                 </div>
@@ -186,8 +206,13 @@ const EditPlanModal = ({ open, onClose, plan, onUpdatePlan }: EditPlanModalProps
                     type="number"
                     min="20"
                     max="200"
-                    value={formData.target_fat}
-                    onChange={(e) => setFormData({ ...formData, target_fat: parseInt(e.target.value) })}
+                    value={formData.target_fat || ''}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        target_fat: parseInt(e.target.value, 10) || 0,
+                      })
+                    }
                     required
                   />
                 </div>


### PR DESCRIPTION
## Summary
- avoid NaN values when editing numeric fields in CreatePlanModal
- avoid NaN values when editing numeric fields in EditPlanModal

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68752fde00fc8325bc8e9a15f9dfb00f