### PR TITLE
Refonte de la carte nutritionnelle

### DIFF
--- a/src/components/NutritionPlanCard.tsx
+++ b/src/components/NutritionPlanCard.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Zap, Drumstick, Sandwich, Nut, Pencil, CheckCircle, Trash2 } from 'lucide-react';
+import type { Database } from '@/types/supabase';
+import { planColors, PlanType } from '@/utils/planColors';
+import { differenceInWeeks } from 'date-fns';
+
+type NutritionPlan = Database['public']['Tables']['nutrition_plans']['Row'];
+
+interface NutritionPlanCardProps {
+  plan: NutritionPlan;
+  onEdit?: (plan: NutritionPlan) => void;
+  onActivate?: (id: string) => void;
+  onDelete?: (id: string) => void;
+}
+
+const NutritionPlanCard = ({ plan, onEdit, onActivate, onDelete }: NutritionPlanCardProps) => {
+  const colors = planColors[plan.type as PlanType] || planColors.maintenance;
+  const weeksAgo = plan.created_at ? differenceInWeeks(new Date(), new Date(plan.created_at)) : 0;
+
+  return (
+    <div className="bg-[#1e1e2e] text-white rounded-2xl shadow-lg overflow-hidden flex flex-col">
+      <div className={`px-4 py-2 flex items-center justify-between ${colors.card} rounded-t-2xl`}> 
+        <div className="flex items-center gap-2">
+          <span className="text-xl font-semibold">{plan.name}</span>
+          {plan.is_active && <Badge className={`${colors.badge} text-white`}>Actif</Badge>}
+        </div>
+        <div className="flex items-center gap-1">
+          {onEdit && (
+            <Button variant="ghost" size="icon" onClick={() => onEdit(plan)} className="h-8 w-8 text-white/80 hover:text-white">
+              <Pencil size={14} />
+            </Button>
+          )}
+          {onActivate && (
+            <Button variant="ghost" size="icon" onClick={() => onActivate(plan.id)} className="h-8 w-8 text-green-400 hover:text-green-300">
+              <CheckCircle size={14} />
+            </Button>
+          )}
+          {onDelete && (
+            <Button variant="ghost" size="icon" onClick={() => onDelete(plan.id)} className="h-8 w-8 text-red-400 hover:text-red-300">
+              <Trash2 size={14} />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="p-4 space-y-2 flex-1">
+        {plan.description && <p className="text-sm text-white/80">{plan.description}</p>}
+        {plan.created_at && (
+          <p className="text-xs text-white/60">Créé il y a {weeksAgo} semaine{weeksAgo > 1 ? 's' : ''}</p>
+        )}
+        <div className="flex flex-wrap gap-2 pt-2">
+          <Badge className="bg-white/10 text-white flex items-center gap-1">
+            <Zap className="h-3 w-3" /> {plan.target_calories} kcal
+          </Badge>
+          <Badge className="bg-white/10 text-white flex items-center gap-1">
+            <Drumstick className="h-3 w-3" /> {plan.target_protein}g prot
+          </Badge>
+          <Badge className="bg-white/10 text-white flex items-center gap-1">
+            <Sandwich className="h-3 w-3" /> {plan.target_carbs}g gluc
+          </Badge>
+          <Badge className="bg-white/10 text-white flex items-center gap-1">
+            <Nut className="h-3 w-3" /> {plan.target_fat}g lip
+          </Badge>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NutritionPlanCard;

--- a/src/components/PlanManager.tsx
+++ b/src/components/PlanManager.tsx
@@ -1,15 +1,14 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Plus, Wrench, Trash2, CheckCircle, Calendar } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Plus } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { useAuth } from '@/hooks/useAuth';
 import { nutritionPlanService } from '@/services/nutritionPlanService';
 import { useToast } from "@/hooks/use-toast";
 import CreatePlanModal from './CreatePlanModal';
 import EditPlanModal from './EditPlanModal';
-import ActivePlanCard from './ActivePlanCard';
+import NutritionPlanCard from './NutritionPlanCard';
 import type { Database } from '@/types/supabase';
 
 type NutritionalPlan = Database['public']['Tables']['nutrition_plans']['Row'];
@@ -34,26 +33,6 @@ const PlanManager = () => {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingPlan, setEditingPlan] = useState<NutritionalPlan | null>(null);
 
-  const planTypeConfig = {
-    'weight-loss': {
-      label: 'Perte de poids',
-      color: 'from-red-400 to-pink-500',
-      bgColor: 'bg-red-100',
-      textColor: 'text-red-700'
-    },
-    'maintenance': {
-      label: 'Maintien',
-      color: 'from-green-400 to-blue-500',
-      bgColor: 'bg-green-100',
-      textColor: 'text-green-700'
-    },
-    'bulk': {
-      label: 'Prise de masse',
-      color: 'from-blue-400 to-purple-500',
-      bgColor: 'bg-blue-100',
-      textColor: 'text-blue-700'
-    }
-  };
 
   const loadPlans = useCallback(async () => {
     if (!user) return;
@@ -222,93 +201,16 @@ const PlanManager = () => {
         </Button>
       </div>
 
-      {/* Plan actif */}
-      {plans.find(plan => plan.is_active) && (
-        <ActivePlanCard
-          plan={plans.find(plan => plan.is_active)!}
-          onDelete={(id) => deletePlan(id)}
-        />
-      )}
-
-      {/* Liste des autres plans */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {plans.filter(plan => !plan.is_active).map((plan) => {
-          const config = planTypeConfig[plan.type as keyof typeof planTypeConfig];
-          return (
-            <Card key={plan.id} className="hover:shadow-md transition-shadow">
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <div className={`w-12 h-12 bg-gradient-to-r ${config.color} rounded-xl flex items-center justify-center`}>
-                    <span className="text-white text-lg font-bold">{plan.name[0]}</span>
-                  </div>
-                  <div className="flex space-x-1">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => activatePlan(plan.id)}
-                      className="h-8 w-8 text-green-500 hover:text-green-700"
-                    >
-                      <CheckCircle size={14} />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setEditingPlan(plan)}
-                      className="h-8 w-8"
-                    >
-                      <Wrench size={14} />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => deletePlan(plan.id)}
-                      className="h-8 w-8 text-red-500 hover:text-red-700"
-                    >
-                      <Trash2 size={14} />
-                    </Button>
-                  </div>
-                </div>
-                <div>
-                  <CardTitle className="text-lg">{plan.name}</CardTitle>
-                  <Badge variant="secondary" className="bg-pink-100 text-pink-700 dark:bg-pink-900/20 dark:text-pink-300 mt-2">
-                    {config.label}
-                  </Badge>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground text-sm mb-4">{plan.description}</p>
-                
-                <div className="space-y-2 mb-4">
-                  <div className="flex justify-between text-sm">
-                    <span>Calories:</span>
-                    <span className="font-medium">{plan.target_calories} kcal</span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span>Protéines:</span>
-                    <span className="font-medium">{plan.target_protein}g</span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span>Glucides:</span>
-                    <span className="font-medium">{plan.target_carbs}g</span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span>Lipides:</span>
-                    <span className="font-medium">{plan.target_fat}g</span>
-                  </div>
-                </div>
-
-                <div className="flex items-center justify-between text-xs text-muted-foreground mb-4">
-                  <div className="flex items-center">
-                    <Calendar size={12} className="mr-1" />
-                    {plan.duration} semaines
-                  </div>
-                  <span>Créé le {new Date(plan.created_at!).toLocaleDateString('fr-FR')}</span>
-                </div>
-
-              </CardContent>
-            </Card>
-          );
-        })}
+        {plans.map((plan) => (
+          <NutritionPlanCard
+            key={plan.id}
+            plan={plan}
+            onActivate={activatePlan}
+            onEdit={() => setEditingPlan(plan)}
+            onDelete={deletePlan}
+          />
+        ))}
       </div>
 
       {plans.length === 0 && (

--- a/src/services/nutritionPlanService.ts
+++ b/src/services/nutritionPlanService.ts
@@ -14,12 +14,14 @@ export const nutritionPlanService = {
       .select('*')
       .eq('user_id', userId)
       .order('created_at', { ascending: false });
-    
+
     if (error) {
       console.error('Error fetching nutrition plans:', error);
       return [];
     }
-    return data || [];
+    if (!data) return [];
+    const hasCustom = data.some(p => p.name !== 'Plan par défaut');
+    return hasCustom ? data.filter(p => p.name !== 'Plan par défaut') : data;
   },
 
   async getActivePlan(userId: string): Promise<NutritionPlan | null> {


### PR DESCRIPTION
## Summary
- implement `NutritionPlanCard` with compact dark design
- filter out default plan when custom plans exist
- display plans using new card in `PlanManager`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687543e907248325b7fde192bfec4edf