### PR TITLE
Amélioration création et affichage des plans

### DIFF
--- a/src/components/CreatePlanModal.tsx
+++ b/src/components/CreatePlanModal.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -147,7 +148,9 @@ const CreatePlanModal = ({ open, onClose, onCreatePlan }: CreatePlanModalProps) 
                 <p className="text-sm text-muted-foreground">Calcul de la suggestion...</p>
               )}
               {!loadingSuggestion && suggestion && (
-                <p className="text-sm text-muted-foreground">{suggestion}</p>
+                <ReactMarkdown className="prose prose-sm text-muted-foreground whitespace-pre-wrap">
+                  {suggestion}
+                </ReactMarkdown>
               )}
               
               <div className="grid grid-cols-2 gap-4">

--- a/src/components/NutritionPlanCard.tsx
+++ b/src/components/NutritionPlanCard.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Zap, Drumstick, Sandwich, Nut, Pencil, CheckCircle, Trash2 } from 'lucide-react';
 import type { Database } from '@/types/supabase';
 import { planColors, PlanType } from '@/utils/planColors';
-import { differenceInWeeks } from 'date-fns';
+import { format } from 'date-fns';
 
 type NutritionPlan = Database['public']['Tables']['nutrition_plans']['Row'];
 
@@ -17,7 +17,7 @@ interface NutritionPlanCardProps {
 
 const NutritionPlanCard = ({ plan, onEdit, onActivate, onDelete }: NutritionPlanCardProps) => {
   const colors = planColors[plan.type as PlanType] || planColors.maintenance;
-  const weeksAgo = plan.created_at ? differenceInWeeks(new Date(), new Date(plan.created_at)) : 0;
+  const createdDate = plan.created_at ? format(new Date(plan.created_at), 'dd/MM/yyyy') : '';
 
   return (
     <div className="bg-[#1e1e2e] text-white rounded-2xl shadow-lg overflow-hidden flex flex-col">
@@ -48,7 +48,7 @@ const NutritionPlanCard = ({ plan, onEdit, onActivate, onDelete }: NutritionPlan
       <div className="p-4 space-y-2 flex-1">
         {plan.description && <p className="text-sm text-white/80">{plan.description}</p>}
         {plan.created_at && (
-          <p className="text-xs text-white/60">Créé il y a {weeksAgo} semaine{weeksAgo > 1 ? 's' : ''}</p>
+          <p className="text-xs text-white/60">Créé le {createdDate}</p>
         )}
         <div className="flex flex-wrap gap-2 pt-2">
           <Badge className="bg-white/10 text-white flex items-center gap-1">

--- a/src/components/PlanManager.tsx
+++ b/src/components/PlanManager.tsx
@@ -195,10 +195,6 @@ const PlanManager = () => {
           <h2 className="text-2xl font-bold text-foreground">Plans alimentaires</h2>
           <p className="text-muted-foreground">Gérez vos plans personnalisés selon vos objectifs</p>
         </div>
-        <Button onClick={() => setShowCreateModal(true)} className="bg-green-500 hover:bg-green-600">
-          <Plus className="mr-2" size={16} />
-          Nouveau plan
-        </Button>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">


### PR DESCRIPTION
## Résumé
- suppression du bouton "Nouveau plan" en doublon
- meilleure mise en forme du texte IA dans la création de plan
- affichage de la date de création sur les cartes de plans

## Test
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68768aa72adc8325a20aa246ca30d059